### PR TITLE
Release v0.9.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9690,7 +9690,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zorai-cli"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-daemon"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-gateway"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "anyhow",
  "futures",
@@ -9800,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-mcp"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9819,7 +9819,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-protocol"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -9837,14 +9837,14 @@ dependencies = [
 
 [[package]]
 name = "zorai-shared"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "zorai-tui"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.39"
+version = "0.9.40"
 edition = "2021"
 license = "MIT"
 authors = ["zorai contributors"]

--- a/crates/zorai-daemon/src/agent/agent_loop/send_message/budget_extension.rs
+++ b/crates/zorai-daemon/src/agent/agent_loop/send_message/budget_extension.rs
@@ -86,12 +86,50 @@ pub(super) fn max_loops_after_successful_budget_extend(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FinishSubagentSynthesis {
+    None,
+    CancelledReport,
+    BudgetTextReport,
+    BudgetErrorReport,
+}
+
+pub(super) fn finish_subagent_synthesis(
+    was_cancelled: bool,
+    in_report_back: bool,
+    has_report: bool,
+    terminated_for_budget: bool,
+    spawned: bool,
+) -> FinishSubagentSynthesis {
+    if has_report {
+        return FinishSubagentSynthesis::None;
+    }
+    if was_cancelled {
+        if in_report_back || spawned {
+            return FinishSubagentSynthesis::CancelledReport;
+        }
+        return FinishSubagentSynthesis::None;
+    }
+    if in_report_back {
+        return FinishSubagentSynthesis::BudgetTextReport;
+    }
+    if terminated_for_budget && spawned {
+        return FinishSubagentSynthesis::BudgetErrorReport;
+    }
+    FinishSubagentSynthesis::None
+}
+
+pub(super) fn should_mark_terminated_after_failed_report_back_entry(entered: bool) -> bool {
+    !entered
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        budget_extension_applies_to_runner, max_loops_after_successful_budget_extend,
-        max_loops_for_budget_report_back, parse_successful_budget_extension,
-        should_exit_report_back_after_live_ceiling_sync,
+        budget_extension_applies_to_runner, finish_subagent_synthesis,
+        max_loops_after_successful_budget_extend, max_loops_for_budget_report_back,
+        parse_successful_budget_extension, should_exit_report_back_after_live_ceiling_sync,
+        should_mark_terminated_after_failed_report_back_entry, FinishSubagentSynthesis,
     };
 
     #[test]
@@ -199,5 +237,40 @@ mod tests {
             loop_count_after_extend_turn < max_after_extend,
             "the extend call consumes the +1 report-back iteration; without a continuation allotment the runner hits max_loops and the dispatcher marks the child completed"
         );
+    }
+
+    #[test]
+    fn cancelled_report_back_must_not_synthesize_budget_exceeded() {
+        assert_eq!(
+            finish_subagent_synthesis(true, true, false, false, true),
+            FinishSubagentSynthesis::CancelledReport,
+            "cancelling during report-back must not record zorai_budget; the dispatcher would tell the parent to extend instead of treating the child as cancelled"
+        );
+        assert_eq!(
+            finish_subagent_synthesis(false, true, false, false, true),
+            FinishSubagentSynthesis::BudgetTextReport
+        );
+        assert_eq!(
+            finish_subagent_synthesis(true, false, false, true, true),
+            FinishSubagentSynthesis::CancelledReport,
+            "a cancelled spawned turn must stay cancelled even if the budget flag was already set"
+        );
+        assert_eq!(
+            finish_subagent_synthesis(false, false, false, true, true),
+            FinishSubagentSynthesis::BudgetErrorReport
+        );
+        assert_eq!(
+            finish_subagent_synthesis(false, true, true, false, true),
+            FinishSubagentSynthesis::None
+        );
+    }
+
+    #[test]
+    fn text_completion_must_terminate_when_report_back_entry_fails() {
+        assert!(
+            should_mark_terminated_after_failed_report_back_entry(false),
+            "the tool-loop path sets terminated_for_budget when enter_execution_budget_report_back fails; text completion must do the same or a spawned child is completed while still over budget"
+        );
+        assert!(!should_mark_terminated_after_failed_report_back_entry(true));
     }
 }

--- a/crates/zorai-daemon/src/agent/agent_loop/send_message/finalize.rs
+++ b/crates/zorai-daemon/src/agent/agent_loop/send_message/finalize.rs
@@ -302,20 +302,7 @@ impl<'a> SendMessageRunner<'a> {
     }
 
     pub(super) async fn finish(mut self) -> Result<SendMessageOutcome> {
-        if self.report_back_phase.is_some() && self.subagent_report.is_none() {
-            let summary = self.synthesize_thread_summary().await;
-            self.capture_text_report_back(&summary).await;
-        } else if self.subagent_report.is_none()
-            && self.terminated_for_budget
-            && self.spawned_subagent_turn_active()
-        {
-            let summary = self.synthesize_thread_summary().await;
-            self.subagent_report = Some(SubagentTurnReport {
-                status: SubagentReportStatus::Error,
-                summary,
-                reason: Some("zorai_budget".to_string()),
-            });
-        }
+        self.apply_finish_subagent_synthesis().await;
         if super::report_back::should_emit_tool_execution_limit_error(
             self.was_cancelled,
             self.max_loops,

--- a/crates/zorai-daemon/src/agent/agent_loop/send_message/report_back.rs
+++ b/crates/zorai-daemon/src/agent/agent_loop/send_message/report_back.rs
@@ -2,9 +2,10 @@ use super::*;
 #[path = "budget_extension.rs"]
 mod budget_extension;
 use budget_extension::{
-    budget_extension_applies_to_runner, max_loops_after_successful_budget_extend,
-    max_loops_for_budget_report_back, parse_successful_budget_extension,
-    should_exit_report_back_after_live_ceiling_sync,
+    budget_extension_applies_to_runner, finish_subagent_synthesis,
+    max_loops_after_successful_budget_extend, max_loops_for_budget_report_back,
+    parse_successful_budget_extension, should_exit_report_back_after_live_ceiling_sync,
+    should_mark_terminated_after_failed_report_back_entry, FinishSubagentSynthesis,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -229,7 +230,13 @@ impl<'a> SendMessageRunner<'a> {
             crate::agent::subagent::context_budget::BudgetStatus::Exceeded {
                 overflow_action: ContextOverflowAction::Error,
                 ..
-            } => self.enter_execution_budget_report_back().await,
+            } => {
+                let entered = self.enter_execution_budget_report_back().await;
+                if should_mark_terminated_after_failed_report_back_entry(entered) {
+                    self.terminated_for_budget = true;
+                }
+                entered
+            }
             _ => false,
         }
     }
@@ -238,6 +245,40 @@ impl<'a> SendMessageRunner<'a> {
         self.report_back_phase = None;
         if let Some(tools) = self.tools_before_report_back.take() {
             self.tools = tools;
+        }
+    }
+
+    pub(super) async fn apply_finish_subagent_synthesis(&mut self) {
+        match finish_subagent_synthesis(
+            self.was_cancelled,
+            self.report_back_phase.is_some(),
+            self.subagent_report.is_some(),
+            self.terminated_for_budget,
+            self.spawned_subagent_turn_active(),
+        ) {
+            FinishSubagentSynthesis::CancelledReport => {
+                let summary = self.synthesize_thread_summary().await;
+                self.subagent_report = Some(SubagentTurnReport {
+                    status: SubagentReportStatus::Cancelled,
+                    summary,
+                    reason: Some("cancelled".to_string()),
+                });
+                self.terminated_for_budget = false;
+                self.exit_report_back_phase();
+            }
+            FinishSubagentSynthesis::BudgetTextReport => {
+                let summary = self.synthesize_thread_summary().await;
+                self.capture_text_report_back(&summary).await;
+            }
+            FinishSubagentSynthesis::BudgetErrorReport => {
+                let summary = self.synthesize_thread_summary().await;
+                self.subagent_report = Some(SubagentTurnReport {
+                    status: SubagentReportStatus::Error,
+                    summary,
+                    reason: Some("zorai_budget".to_string()),
+                });
+            }
+            FinishSubagentSynthesis::None => {}
         }
     }
 
@@ -358,7 +399,8 @@ impl<'a> SendMessageRunner<'a> {
     }
 
     pub(super) async fn capture_text_report_back(&mut self, content: &str) {
-        if self.report_back_phase.is_none() || self.subagent_report.is_some() {
+        if self.was_cancelled || self.report_back_phase.is_none() || self.subagent_report.is_some()
+        {
             return;
         }
         let summary = {
@@ -452,7 +494,6 @@ impl<'a> SendMessageRunner<'a> {
         true
     }
 }
-
 #[cfg(test)]
 #[path = "report_back_tests.rs"]
 mod tests;

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -75,7 +75,7 @@ Minimal example:
 ```json
 {
   "name": "zorai-plugin-example",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "zoraiPlugin": {
     "entry": "dist/zorai-plugin.js",
     "format": "script"
@@ -102,7 +102,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.9.39",
+  version: "0.9.40",
   components: {
     ExamplePanel,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zorai",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zorai",
-      "version": "0.9.39",
+      "version": "0.9.40",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zorai",
   "private": true,
-  "version": "0.9.39",
+  "version": "0.9.40",
   "description": "Daemon-first agentic runtime with AI-native workflows",
   "homepage": "https://zorai.app",
   "author": {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -58,7 +58,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>Zorai - Agent Orchestration Workspace</p>
-                    <p>Version 0.9.39</p>
+                    <p>Version 0.9.40</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A thread-first agent orchestration workspace with durable goals, workspace boards,
                         approvals, tools, and daemon-backed runtime state.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.9.39",
+        version: "0.9.40",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.9.39",
+        version: "0.9.40",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/zorai/features/settings/SettingsPanels.tsx
+++ b/frontend/src/zorai/features/settings/SettingsPanels.tsx
@@ -63,7 +63,7 @@ export const conciergeReasoningEffortOptions: Array<{ value: AgentSettings["reas
   { value: "xhigh", label: "xhigh" },
   { value: "max", label: "max" },
 ];
-const APP_VERSION = "0.9.39";
+const APP_VERSION = "0.9.40";
 const APP_AUTHOR = "Mariusz Kurman";
 const APP_GITHUB = "mkurman/zorai";
 const APP_HOMEPAGE = "zorai.app";

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zor-ai",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://zorai.app",


### PR DESCRIPTION
Merge develop into main for v0.9.40.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes parent/child subagent completion semantics around cancellation and budget report-back; behavior is covered by new unit tests but affects orchestration edge cases.
> 
> **Overview**
> **Release v0.9.40** bumps workspace and UI/npm version strings from **0.9.39** to **0.9.40** (lockfiles, About/settings, built-in plugins).
> 
> The substantive daemon change fixes **spawned subagent** teardown when **execution budget** and **report-back** interact:
> 
> - **`finish_subagent_synthesis`** centralizes what happens at turn end when there is no terminal report yet: **cancelled** (including during report-back or a spawned turn), **budget text report-back**, or **budget error** (`zorai_budget`), instead of ad hoc logic in **`finish`**.
> - **`apply_finish_subagent_synthesis`** in report-back applies those outcomes (cancelled report clears **`terminated_for_budget`**; budget paths synthesize summaries as before).
> - **`capture_text_report_back`** no longer runs when the turn was **cancelled**, so a cancel during report-back is not mislabeled as budget exceeded (which would mislead the parent dispatcher).
> - **`maybe_force_budget_report_back`** sets **`terminated_for_budget`** when **`enter_execution_budget_report_back`** fails, matching the tool-loop path so spawned children are not marked completed while still over budget.
> 
> Unit tests in **`budget_extension.rs`** lock in the cancelled vs budget behavior and failed report-back entry termination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef8b90aa26596dc5b9e44db8c45611f8d153b37a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->