### PR TITLE
Release v0.9.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9690,7 +9690,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zorai-cli"
-version = "0.9.40"
+version = "0.9.41"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-daemon"
-version = "0.9.40"
+version = "0.9.41"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-gateway"
-version = "0.9.40"
+version = "0.9.41"
 dependencies = [
  "anyhow",
  "futures",
@@ -9800,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-mcp"
-version = "0.9.40"
+version = "0.9.41"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9819,7 +9819,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-protocol"
-version = "0.9.40"
+version = "0.9.41"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -9837,14 +9837,14 @@ dependencies = [
 
 [[package]]
 name = "zorai-shared"
-version = "0.9.40"
+version = "0.9.41"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "zorai-tui"
-version = "0.9.40"
+version = "0.9.41"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.40"
+version = "0.9.41"
 edition = "2021"
 license = "MIT"
 authors = ["zorai contributors"]

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -75,7 +75,7 @@ Minimal example:
 ```json
 {
   "name": "zorai-plugin-example",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "zoraiPlugin": {
     "entry": "dist/zorai-plugin.js",
     "format": "script"
@@ -102,7 +102,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.9.40",
+  version: "0.9.41",
   components: {
     ExamplePanel,
   },

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -93,7 +93,6 @@
       /* Brand wordmark */
       #zorai-boot .zorai-boot-word {
         font-size: 34px;
-        font-weight: 700;
         letter-spacing: 0.32em;
         text-indent: 0.32em; /* keeps letters optically centered with tracking */
         /* text-transform: uppercase; */

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zorai",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zorai",
-      "version": "0.9.40",
+      "version": "0.9.41",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zorai",
   "private": true,
-  "version": "0.9.40",
+  "version": "0.9.41",
   "description": "Daemon-first agentic runtime with AI-native workflows",
   "homepage": "https://zorai.app",
   "author": {

--- a/frontend/src/components/agent-chat-panel/chat.css
+++ b/frontend/src/components/agent-chat-panel/chat.css
@@ -705,6 +705,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: var(--text-sm-plus);
 }
 
 .acp-tool-row__status {
@@ -717,7 +718,7 @@
 }
 
 .acp-tool-row__badge {
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: 700;
 }
 
@@ -896,7 +897,7 @@
   min-width: 0;
   max-width: 100%;
   overflow-wrap: anywhere;
-  font-size: var(--text-sm);
+  font-size: var(--text-sm-plus);
   line-height: 1.65;
 }
 

--- a/frontend/src/components/agent-chat-panel/runtime/threadTurnState.test.ts
+++ b/frontend/src/components/agent-chat-panel/runtime/threadTurnState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentMessage } from "@/lib/agentStore";
-import { threadTurnIsActive } from "./threadTurnState";
+import { finalizeThreadTurnMessages, threadTurnIsActive } from "./threadTurnState";
 
 function message(partial: Partial<AgentMessage> & Pick<AgentMessage, "id" | "role">): AgentMessage {
   return {
@@ -43,5 +43,31 @@ describe("threadTurnIsActive", () => {
       message({ id: "user-2", role: "user", content: "queued follow-up" }),
       message({ id: "asst-final", role: "assistant", content: "done", isStreaming: false }),
     ])).toBe(true);
+  });
+
+  it("clears after stop finalizes leftover in-flight tool rows", () => {
+    // Why: abort in the tool_call gap only used to clear assistant isStreaming.
+    // requested/executing rows then kept threadTurnIsActive true, so the composer
+    // queued instead of sending the next follow-up.
+    const messages = [
+      message({ id: "asst-1", role: "assistant", content: "Calling tools...", isStreaming: false }),
+      message({ id: "tool-1", role: "tool", toolCallId: "call-1", toolName: "read_file", toolStatus: "requested" }),
+    ];
+    expect(threadTurnIsActive(messages)).toBe(true);
+    expect(threadTurnIsActive(finalizeThreadTurnMessages(messages))).toBe(false);
+  });
+});
+
+describe("finalizeThreadTurnMessages", () => {
+  it("closes leftover executing tools as stopped errors without touching completed ones", () => {
+    const finalized = finalizeThreadTurnMessages([
+      message({ id: "tool-open", role: "tool", toolCallId: "call-1", toolName: "read_file", toolStatus: "executing" }),
+      message({ id: "tool-done", role: "tool", toolCallId: "call-2", toolName: "read_file", toolStatus: "done", content: "ok" }),
+      message({ id: "asst-stale", role: "assistant", content: "", isStreaming: true }),
+    ]);
+
+    expect(finalized[0]).toMatchObject({ toolStatus: "error", content: "(stopped)" });
+    expect(finalized[1]).toMatchObject({ toolStatus: "done", content: "ok" });
+    expect(finalized[2]?.isStreaming).toBe(false);
   });
 });

--- a/frontend/src/components/agent-chat-panel/runtime/threadTurnState.test.ts
+++ b/frontend/src/components/agent-chat-panel/runtime/threadTurnState.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "@/lib/agentStore";
+import { threadTurnIsActive } from "./threadTurnState";
+
+function message(partial: Partial<AgentMessage> & Pick<AgentMessage, "id" | "role">): AgentMessage {
+  return {
+    threadId: "thread-1",
+    createdAt: 1,
+    content: "",
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    isCompactionSummary: false,
+    ...partial,
+  };
+}
+
+describe("threadTurnIsActive", () => {
+  it("stays active while a tool call is in flight even if the last assistant is no longer streaming", () => {
+    // Why: the composer used to treat tool_call's isStreaming=false gap as "turn
+    // finished" and dispatch the next queued follow-up onto a still-running daemon turn.
+    expect(threadTurnIsActive([
+      message({ id: "user-1", role: "user", content: "do the work" }),
+      message({ id: "asst-1", role: "assistant", content: "Calling tools...", isStreaming: false }),
+      message({ id: "tool-1", role: "tool", toolCallId: "call-1", toolName: "read_file", toolStatus: "requested" }),
+    ])).toBe(true);
+  });
+
+  it("clears after the matching tool result arrives and no assistant is streaming", () => {
+    expect(threadTurnIsActive([
+      message({ id: "asst-1", role: "assistant", content: "Calling tools...", isStreaming: false }),
+      message({ id: "tool-1", role: "tool", toolCallId: "call-1", toolName: "read_file", toolStatus: "requested" }),
+      message({ id: "tool-1-done", role: "tool", toolCallId: "call-1", toolName: "read_file", toolStatus: "done", content: "ok" }),
+    ])).toBe(false);
+  });
+
+  it("stays active for a leftover buried streaming assistant after a later message is finalized", () => {
+    // Why: a mid-turn queued send can bury the previous streaming placeholder.
+    // isStreamingResponse used .some(), so this leftover kept the UI working forever
+    // and blocked later queue/send-now dispatch unless every streaming flag is cleared.
+    expect(threadTurnIsActive([
+      message({ id: "asst-stale", role: "assistant", content: "", isStreaming: true }),
+      message({ id: "user-2", role: "user", content: "queued follow-up" }),
+      message({ id: "asst-final", role: "assistant", content: "done", isStreaming: false }),
+    ])).toBe(true);
+  });
+});

--- a/frontend/src/components/agent-chat-panel/runtime/threadTurnState.ts
+++ b/frontend/src/components/agent-chat-panel/runtime/threadTurnState.ts
@@ -1,6 +1,11 @@
 import { useAgentStore } from "@/lib/agentStore";
 import type { AgentMessage } from "@/lib/agentStore";
 
+function isOpenToolCall(message: AgentMessage): boolean {
+  return message.role === "tool"
+    && (message.toolStatus === "requested" || message.toolStatus === "executing");
+}
+
 export function threadTurnIsActive(messages: AgentMessage[]): boolean {
   const openToolCalls = new Set<string>();
   let hasStreamingAssistant = false;
@@ -22,20 +27,39 @@ export function threadTurnIsActive(messages: AgentMessage[]): boolean {
   return hasStreamingAssistant || openToolCalls.size > 0;
 }
 
+export function finalizeThreadTurnMessages(messages: AgentMessage[]): AgentMessage[] {
+  return messages.map((message) => {
+    if (message.role === "assistant" && message.isStreaming === true) {
+      return { ...message, isStreaming: false };
+    }
+    if (isOpenToolCall(message)) {
+      return {
+        ...message,
+        toolStatus: "error",
+        content: message.content || "(stopped)",
+      };
+    }
+    return message;
+  });
+}
+
+function threadTurnNeedsFinalization(messages: AgentMessage[]): boolean {
+  return messages.some((message) => (
+    (message.role === "assistant" && message.isStreaming === true)
+    || isOpenToolCall(message)
+  ));
+}
+
 export function finalizeStreamingAssistantMessages(threadId: string): void {
   useAgentStore.setState((state) => {
     const list = state.messages[threadId];
-    if (!list?.some((message) => message.role === "assistant" && message.isStreaming === true)) {
+    if (!list || !threadTurnNeedsFinalization(list)) {
       return state;
     }
     return {
       messages: {
         ...state.messages,
-        [threadId]: list.map((message) => (
-          message.role === "assistant" && message.isStreaming === true
-            ? { ...message, isStreaming: false }
-            : message
-        )),
+        [threadId]: finalizeThreadTurnMessages(list),
       },
     };
   });

--- a/frontend/src/components/agent-chat-panel/runtime/threadTurnState.ts
+++ b/frontend/src/components/agent-chat-panel/runtime/threadTurnState.ts
@@ -1,0 +1,42 @@
+import { useAgentStore } from "@/lib/agentStore";
+import type { AgentMessage } from "@/lib/agentStore";
+
+export function threadTurnIsActive(messages: AgentMessage[]): boolean {
+  const openToolCalls = new Set<string>();
+  let hasStreamingAssistant = false;
+
+  for (const message of messages) {
+    if (message.role === "assistant" && message.isStreaming === true) {
+      hasStreamingAssistant = true;
+    }
+    if (message.role !== "tool" || !message.toolCallId) {
+      continue;
+    }
+    if (message.toolStatus === "requested" || message.toolStatus === "executing") {
+      openToolCalls.add(message.toolCallId);
+    } else if (message.toolStatus === "done" || message.toolStatus === "error") {
+      openToolCalls.delete(message.toolCallId);
+    }
+  }
+
+  return hasStreamingAssistant || openToolCalls.size > 0;
+}
+
+export function finalizeStreamingAssistantMessages(threadId: string): void {
+  useAgentStore.setState((state) => {
+    const list = state.messages[threadId];
+    if (!list?.some((message) => message.role === "assistant" && message.isStreaming === true)) {
+      return state;
+    }
+    return {
+      messages: {
+        ...state.messages,
+        [threadId]: list.map((message) => (
+          message.role === "assistant" && message.isStreaming === true
+            ? { ...message, isStreaming: false }
+            : message
+        )),
+      },
+    };
+  });
+}

--- a/frontend/src/components/agent-chat-panel/runtime/useAgentChatPanelProviderValue.ts
+++ b/frontend/src/components/agent-chat-panel/runtime/useAgentChatPanelProviderValue.ts
@@ -33,6 +33,7 @@ import {
   shouldFollowThreadHistoryBottom,
 } from "./threadHistoryScroll";
 import { useLegacyAgentMessaging } from "./useLegacyAgentMessaging";
+import { finalizeStreamingAssistantMessages, threadTurnIsActive } from "./threadTurnState";
 import type {
   AgentChatPanelRuntimeValue,
   AgentChatPanelView,
@@ -431,6 +432,7 @@ export function useAgentChatPanelProviderValue(): {
     if (lastMessage?.role === "assistant" && lastMessage.isStreaming) {
       updateLastAssistantMessage(targetThreadId, lastMessage.content || "(stopped)", false);
     }
+    finalizeStreamingAssistantMessages(targetThreadId);
   }, [activeThreadId, agentSettings.agent_backend, updateLastAssistantMessage]);
 
   const { sendMessageLegacy } = useLegacyAgentMessaging({
@@ -625,7 +627,7 @@ export function useAgentChatPanelProviderValue(): {
     () => filterThreadsForBrowserView(searchedThreads, view),
     [searchedThreads, view],
   );
-  const isStreamingResponse = messages.some((message) => message.role === "assistant" && message.isStreaming === true);
+  const isStreamingResponse = threadTurnIsActive(messages);
   const canOpenSpawnedThread = useCallback((run: AgentRun) => {
     if (!run.thread_id) {
       return false;

--- a/frontend/src/components/agent-chat-panel/runtime/useDaemonAgentActions.ts
+++ b/frontend/src/components/agent-chat-panel/runtime/useDaemonAgentActions.ts
@@ -495,8 +495,9 @@ export function useDaemonAgentActions({
 
       daemonLocalThreadRef.current = threadId;
 
+      const daemonThreadId = daemonThreadIdRef.current ?? thread?.daemonThreadId ?? null;
       let contextMessages: unknown[] | undefined;
-      {
+      if (!daemonThreadId) {
         const existingMessages = useAgentStore.getState().getThreadMessages(threadId);
         const historyMessages = existingMessages
           .filter((message) => !message.isStreaming && !message.isCompactionSummary)
@@ -527,7 +528,6 @@ export function useDaemonAgentActions({
         }
       }
 
-      const daemonThreadId = daemonThreadIdRef.current;
       const targetAgentId = resolveNewThreadTargetAgent(thread, daemonThreadId);
       await sendAgentMessage(
         daemonThreadId || threadId,

--- a/frontend/src/components/agent-chat-panel/runtime/useDaemonAgentEvents.ts
+++ b/frontend/src/components/agent-chat-panel/runtime/useDaemonAgentEvents.ts
@@ -29,6 +29,7 @@ import {
   handleTodoUpdateEvent,
   handleWorkspaceCommand,
 } from "./daemonEventHandlers";
+import { finalizeStreamingAssistantMessages } from "./threadTurnState";
 
 export function resolveDaemonEventLocalThreadId(
   event: any,
@@ -305,6 +306,7 @@ export function useDaemonAgentEvents({
           if (typeof event.message_id === "string" && event.message_id.length > 0) {
             replaceMessageIdAtTail(tid, event.message_id, (m) => m.role === "assistant");
           }
+          finalizeStreamingAssistantMessages(tid);
           break;
         }
         case "tool_call": {
@@ -413,6 +415,7 @@ export function useDaemonAgentEvents({
           useAgentMissionStore.getState().setSharedCursorMode("idle");
           ensureStreamingAssistantMessage(tid);
           updateLastAssistantMessage(tid, `Error: ${event.message}`, false);
+          finalizeStreamingAssistantMessages(tid);
           break;
         }
         case "thread_created": {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -58,7 +58,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>Zorai - Agent Orchestration Workspace</p>
-                    <p>Version 0.9.40</p>
+                    <p>Version 0.9.41</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A thread-first agent orchestration workspace with durable goals, workspace boards,
                         approvals, tools, and daemon-backed runtime state.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.9.40",
+        version: "0.9.41",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.9.40",
+        version: "0.9.41",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/styles/global/tokens.css
+++ b/frontend/src/styles/global/tokens.css
@@ -240,6 +240,7 @@
   --text-2xs: 10px;
   --text-xs: 11px;
   --text-sm: 12px;
+  --text-sm-plus: 13px;
   --text-base: 14px;
   --text-md: 15px;
   --text-lg: 16px;

--- a/frontend/src/zorai/features/settings/SettingsPanels.tsx
+++ b/frontend/src/zorai/features/settings/SettingsPanels.tsx
@@ -63,7 +63,7 @@ export const conciergeReasoningEffortOptions: Array<{ value: AgentSettings["reas
   { value: "xhigh", label: "xhigh" },
   { value: "max", label: "max" },
 ];
-const APP_VERSION = "0.9.40";
+const APP_VERSION = "0.9.41";
 const APP_AUTHOR = "Mariusz Kurman";
 const APP_GITHUB = "mkurman/zorai";
 const APP_HOMEPAGE = "zorai.app";

--- a/frontend/src/zorai/features/threads/NativeThreadMessageBubble.tsx
+++ b/frontend/src/zorai/features/threads/NativeThreadMessageBubble.tsx
@@ -27,6 +27,9 @@ export const NativeThreadMessageBubble = memo(function NativeThreadMessageBubble
   speechQueued,
   onSpeak,
   onRetry,
+  onFeedback,
+  onRegenerate,
+  onDelete,
 }: {
   message: AgentMessage;
   threadAgentName?: string;
@@ -38,9 +41,14 @@ export const NativeThreadMessageBubble = memo(function NativeThreadMessageBubble
   speechQueued: boolean;
   onSpeak: () => void;
   onRetry?: () => void;
+  onFeedback?: (reaction: "up" | "down" | null) => void | Promise<void>;
+  onRegenerate?: () => void;
+  onDelete?: () => void;
 }) {
   const [retryDismissed, setRetryDismissed] = useState(false);
+  const [copied, setCopied] = useState(false);
   const fromUser = message.role === "user";
+  const isAssistant = message.role === "assistant";
   const author = message.authorAgentName ?? (fromUser ? "You" : message.role === "assistant" ? (threadAgentName ?? "Zorai") : message.role);
   const tokenText = message.totalTokens > 0 ? `${message.totalTokens.toLocaleString()} tokens` : null;
   const hasVisibleContent = message.content.trim().length > 0;
@@ -79,6 +87,58 @@ export const NativeThreadMessageBubble = memo(function NativeThreadMessageBubble
         </div>
       ) : null}
       <div className="zorai-message__actions">
+        {message.content.trim() ? (
+          <button
+            type="button"
+            className="zorai-ghost-button zorai-message-action"
+            title={copied ? "Copied" : "Copy message"}
+            aria-label={copied ? "Copied" : "Copy message"}
+            onClick={() => {
+              try {
+                navigator.clipboard.writeText(message.content);
+              } catch {
+                // Ignore clipboard failures.
+              }
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1500);
+            }}
+          >
+            <MessageActionIcon kind={copied ? "copied" : "copy"} />
+          </button>
+        ) : null}
+        {isAssistant && onFeedback ? (
+          <>
+            <button
+              type="button"
+              className={["zorai-ghost-button zorai-message-action", message.feedback === "up" ? "zorai-button--active" : ""].filter(Boolean).join(" ")}
+              title={message.feedback === "up" ? "Clear positive feedback" : "Good response"}
+              aria-label={message.feedback === "up" ? "Clear positive feedback" : "Good response"}
+              onClick={() => { void onFeedback(message.feedback === "up" ? null : "up"); }}
+            >
+              <MessageActionIcon kind="thumb-up" filled={message.feedback === "up"} />
+            </button>
+            <button
+              type="button"
+              className={["zorai-ghost-button zorai-message-action", message.feedback === "down" ? "zorai-button--active" : ""].filter(Boolean).join(" ")}
+              title={message.feedback === "down" ? "Clear negative feedback" : "Bad response"}
+              aria-label={message.feedback === "down" ? "Clear negative feedback" : "Bad response"}
+              onClick={() => { void onFeedback(message.feedback === "down" ? null : "down"); }}
+            >
+              <MessageActionIcon kind="thumb-down" filled={message.feedback === "down"} />
+            </button>
+          </>
+        ) : null}
+        {isAssistant && onRegenerate && !message.isStreaming ? (
+          <button
+            type="button"
+            className="zorai-ghost-button zorai-message-action"
+            title="Regenerate response"
+            aria-label="Regenerate response"
+            onClick={onRegenerate}
+          >
+            <MessageActionIcon kind="regenerate" />
+          </button>
+        ) : null}
         {ttsEnabled && message.content.trim() ? (
           <button
             type="button"
@@ -100,6 +160,17 @@ export const NativeThreadMessageBubble = memo(function NativeThreadMessageBubble
             <MessageActionIcon kind="pin" />
           </button>
         )}
+        {onDelete ? (
+          <button
+            type="button"
+            className="zorai-ghost-button zorai-message-action"
+            title="Delete message"
+            aria-label="Delete message"
+            onClick={onDelete}
+          >
+            <MessageActionIcon kind="delete" />
+          </button>
+        ) : null}
       </div>
     </article>
   );
@@ -111,9 +182,12 @@ export const NativeThreadMessageBubble = memo(function NativeThreadMessageBubble
   && previous.speechLoading === next.speechLoading
   && previous.speechQueued === next.speechQueued
   && previous.onRetry === next.onRetry
+  && previous.onFeedback === next.onFeedback
+  && previous.onRegenerate === next.onRegenerate
+  && previous.onDelete === next.onDelete
 ));
 
-function MessageActionIcon({ kind, filled = false, animated = false }: { kind: "speak" | "pin"; filled?: boolean; animated?: boolean }) {
+function MessageActionIcon({ kind, filled = false, animated = false }: { kind: "speak" | "pin" | "copy" | "copied" | "thumb-up" | "thumb-down" | "regenerate" | "delete"; filled?: boolean; animated?: boolean }) {
   if (kind === "speak") {
     return (
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -123,10 +197,68 @@ function MessageActionIcon({ kind, filled = false, animated = false }: { kind: "
       </svg>
     );
   }
+  if (kind === "pin") {
+    return (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M12 17v5" />
+        <path d="M9 3h6l-1 7 3 3v2H7v-2l3-3-1-7z" />
+      </svg>
+    );
+  }
+  if (kind === "copy") {
+    return (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <rect x="9" y="9" width="13" height="13" rx="2" />
+        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+      </svg>
+    );
+  }
+  if (kind === "copied") {
+    return (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+    );
+  }
+  if (kind === "thumb-up") {
+    return (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M7 10v12" />
+        <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z" />
+      </svg>
+    );
+  }
+  if (kind === "thumb-down") {
+    return (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M17 14V2" />
+        <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z" />
+      </svg>
+    );
+  }
+  if (kind === "regenerate") {
+    return (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+        <path d="M21 3v6h-6" />
+      </svg>
+    );
+  }
+  if (kind === "delete") {
+    return (
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M3 6h18" />
+        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+        <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+        <line x1="10" y1="11" x2="10" y2="17" />
+        <line x1="14" y1="11" x2="14" y2="17" />
+      </svg>
+    );
+  }
   return (
     <svg width="15" height="15" viewBox="0 0 24 24" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M12 17v5" />
-      <path d="M9 3h6l-1 7 3 3v2H7v-2l3-3-1-7z" />
+      <path d="M17 14V2" />
+      <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z" />
     </svg>
   );
 }

--- a/frontend/src/zorai/features/threads/ThreadActivityRow.tsx
+++ b/frontend/src/zorai/features/threads/ThreadActivityRow.tsx
@@ -147,9 +147,9 @@ export function ThreadActivityRow({
                 id={`zorai-operation-${operation.operationId}`}
                 className="zorai-operation-row"
               >
-                <span className={`zorai-status-pill zorai-status-pill--${state}`}>{state}</span>
-                <code>{operation.operationId}</code>
-                {operation.tool ? <span>{operation.tool}</span> : null}
+                {state && state !== "unknown" ? <span className={`zorai-status-pill zorai-status-pill--${state}`}>{state}</span> : null}
+                {operation.operationId && operation.operationId !== "unknown" ? <code>{operation.operationId}</code> : null }
+                {operation.tool ? <span className="zorai-operation-tool">{operation.tool}</span> : null}
                 {actionable ? (
                   <div className="zorai-card-actions">
                     <button

--- a/frontend/src/zorai/features/threads/ThreadsContextPanel.tsx
+++ b/frontend/src/zorai/features/threads/ThreadsContextPanel.tsx
@@ -179,7 +179,7 @@ function TodoContext({ todos }: { todos: AgentTodoItem[] }) {
         <article key={todo.id} className="zorai-todo-context-item">
           <span className={`zorai-todo-checkbox zorai-todo-checkbox--${todo.status}`} aria-hidden="true" />
           <div>
-            <strong>{todo.content}</strong>
+            <span>{todo.content}</span>
             <span>{todo.status.replace(/_/g, " ")}</span>
           </div>
         </article>

--- a/frontend/src/zorai/features/threads/ThreadsContextPanel.tsx
+++ b/frontend/src/zorai/features/threads/ThreadsContextPanel.tsx
@@ -179,8 +179,8 @@ function TodoContext({ todos }: { todos: AgentTodoItem[] }) {
         <article key={todo.id} className="zorai-todo-context-item">
           <span className={`zorai-todo-checkbox zorai-todo-checkbox--${todo.status}`} aria-hidden="true" />
           <div>
-            <span>{todo.content}</span>
-            <span>{todo.status.replace(/_/g, " ")}</span>
+            <span className="zorai-todo-context-title">{todo.content}</span>
+            <span className="zorai-todo-context-status">{todo.status.replace(/_/g, " ")}</span>
           </div>
         </article>
       ))}

--- a/frontend/src/zorai/features/threads/ThreadsView.tsx
+++ b/frontend/src/zorai/features/threads/ThreadsView.tsx
@@ -46,6 +46,19 @@ export function ThreadsView() {
     () => [...runtime.messages].reverse().find((message) => message.role === "user" && message.content.trim()),
     [runtime.messages],
   );
+  const regenerateAssistantMessage = useCallback((messageId: string) => {
+    const index = runtime.messages.findIndex((entry) => entry.id === messageId);
+    if (index <= 0) return;
+    const previousUserMessage = runtime.messages
+      .slice(0, index)
+      .reverse()
+      .find((entry) => entry.role === "user" && entry.content.trim());
+    if (!previousUserMessage) return;
+    runtime.sendMessage({
+      text: previousUserMessage.content,
+      localContentBlocks: previousUserMessage.contentBlocks,
+    });
+  }, [runtime.messages, runtime.sendMessage]);
   const retryLastMessage = useCallback(() => {
     if (!latestUserMessage) return;
     runtime.sendMessage({
@@ -212,6 +225,13 @@ export function ThreadsView() {
               speechLoading={speech.loadingMessageId === message.id}
               speechQueued={speech.queuedMessageIds.includes(message.id)}
               onSpeak={() => void speech.speakMessage(message)}
+              onFeedback={message.role === "assistant"
+                ? (reaction) => runtime.submitMessageFeedback(runtime.activeThread?.id ?? message.threadId, message.id, reaction)
+                : undefined}
+              onRegenerate={message.role === "assistant" ? () => regenerateAssistantMessage(message.id) : undefined}
+              onDelete={runtime.activeThread?.id || message.threadId
+                ? () => runtime.deleteMessage(runtime.activeThread?.id ?? message.threadId, message.id)
+                : undefined}
               onRetry={isRetryableErrorMessage(message)
                 && isMessageFromCurrentViewSession(message, viewMountedAtRef.current)
                 && latestUserMessage
@@ -299,7 +319,7 @@ function ThreadHeader({
         </button>
         <button
           type="button"
-          className="zorai-status-pill zorai-operations-indicator"
+          className="zorai-ghost-button"
           disabled={activeOperationCount === 0}
           onClick={onOpenOperations}
         >

--- a/frontend/src/zorai/features/threads/composerQueue.test.ts
+++ b/frontend/src/zorai/features/threads/composerQueue.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "@/lib/agentStore";
+import { threadTurnIsActive } from "@/components/agent-chat-panel/runtime/threadTurnState";
 import {
   createQueuedComposerMessage,
   queuedComposerLabel,
@@ -37,6 +39,44 @@ describe("queued composer follow-ups", () => {
   it("holds the remaining queue while a send-now interrupt is waiting for the stream to close", () => {
     expect(shouldDispatchQueuedFollowUp({
       isStreaming: true,
+      awaitingStreamStart: false,
+      hasSendNow: true,
+      queueLength: 1,
+    })).toBe(false);
+  });
+
+  it("does not auto-send the next follow-up during the tool_call gap", () => {
+    const isStreaming = threadTurnIsActive([
+      {
+        id: "asst-1",
+        threadId: "thread-1",
+        createdAt: 1,
+        role: "assistant",
+        content: "Calling tools...",
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        isCompactionSummary: false,
+        isStreaming: false,
+      } satisfies AgentMessage,
+      {
+        id: "tool-1",
+        threadId: "thread-1",
+        createdAt: 2,
+        role: "tool",
+        content: "",
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        isCompactionSummary: false,
+        toolCallId: "call-1",
+        toolName: "read_file",
+        toolStatus: "requested",
+      } satisfies AgentMessage,
+    ]);
+
+    expect(shouldDispatchQueuedFollowUp({
+      isStreaming,
       awaitingStreamStart: false,
       hasSendNow: true,
       queueLength: 1,

--- a/frontend/src/zorai/features/threads/composerQueue.test.ts
+++ b/frontend/src/zorai/features/threads/composerQueue.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentMessage } from "@/lib/agentStore";
-import { threadTurnIsActive } from "@/components/agent-chat-panel/runtime/threadTurnState";
+import { finalizeThreadTurnMessages, threadTurnIsActive } from "@/components/agent-chat-panel/runtime/threadTurnState";
 import {
   createQueuedComposerMessage,
   queuedComposerLabel,
@@ -81,5 +81,43 @@ describe("queued composer follow-ups", () => {
       hasSendNow: true,
       queueLength: 1,
     })).toBe(false);
+  });
+
+  it("dispatches the send-now follow-up after stop closes leftover tool rows", () => {
+    const isStreaming = threadTurnIsActive(finalizeThreadTurnMessages([
+      {
+        id: "asst-1",
+        threadId: "thread-1",
+        createdAt: 1,
+        role: "assistant",
+        content: "Calling tools...",
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        isCompactionSummary: false,
+        isStreaming: false,
+      } satisfies AgentMessage,
+      {
+        id: "tool-1",
+        threadId: "thread-1",
+        createdAt: 2,
+        role: "tool",
+        content: "",
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        isCompactionSummary: false,
+        toolCallId: "call-1",
+        toolName: "read_file",
+        toolStatus: "requested",
+      } satisfies AgentMessage,
+    ]));
+
+    expect(shouldDispatchQueuedFollowUp({
+      isStreaming,
+      awaitingStreamStart: false,
+      hasSendNow: true,
+      queueLength: 0,
+    })).toBe(true);
   });
 });

--- a/frontend/src/zorai/styles/zorai.css
+++ b/frontend/src/zorai/styles/zorai.css
@@ -351,7 +351,11 @@
   box-shadow: inset 0 0 24px rgba(125, 219, 200, 0.06);
 }
 
-.zorai-thread-title,
+.zorai-thread-title {
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
 .zorai-rail-card strong,
 .zorai-metric-card strong {
   font-size: var(--text-base);
@@ -678,6 +682,30 @@
   display: flex;
   justify-content: flex-end;
   gap: 6px;
+  opacity: 0;
+  transform: translateY(2px);
+  transition: opacity 160ms ease-out, transform 160ms ease-out;
+  pointer-events: none;
+}
+
+.zorai-message:hover .zorai-message__actions,
+.zorai-message:focus-within .zorai-message__actions {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.zorai-message__actions:has(.zorai-button--active) {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .zorai-message__actions {
+    transform: none;
+    transition: none;
+  }
 }
 
 .zorai-message-action {
@@ -687,6 +715,8 @@
   height: 26px;
   padding: 0;
   border-radius: 7px;
+  border: 0;
+  background: none;
 }
 
 .zorai-message-retry {
@@ -923,16 +953,17 @@
 
 .zorai-todo-context-item span:not(.zorai-todo-checkbox) {
   color: var(--zorai-muted);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
 }
 
 .zorai-todo-checkbox {
   width: 12px;
   height: 12px;
-  margin-top: 2px;
+  margin-top: 3px;
   border: 1px solid var(--zorai-border-strong);
   border-radius: 3px;
   background: #05070b;
+  font-size: var(--text-xs);
 }
 
 .zorai-todo-checkbox--completed,
@@ -1284,7 +1315,7 @@
   background: transparent;
   color: var(--zorai-text);
   padding: 12px 14px 6px;
-  font-size: var(--text-base);
+  font-size: var(--text-sm-plus);
   line-height: 1.5;
   box-sizing: border-box;
 }
@@ -1435,6 +1466,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 100%;
   color: var(--zorai-muted);
 }
 
@@ -1571,6 +1603,11 @@
   background: var(--zorai-bg-panel);
   color: var(--zorai-muted);
   cursor: pointer;
+  font-size: var(--text-sm);
+}
+
+.zorai-context-tabs button[class*="zorai-context-tab"] {
+  height: 100%;
 }
 
 .zorai-context-header {
@@ -2403,7 +2440,7 @@
   border: 0;
   background: transparent;
   cursor: pointer;
-  font-size: var(--text-sm);
+  font-size: var(--text-sm-plus);
 }
 
 .zorai-thread-activity__summary strong {

--- a/frontend/src/zorai/styles/zorai.css
+++ b/frontend/src/zorai/styles/zorai.css
@@ -944,14 +944,21 @@
   border-bottom: 1px solid var(--zorai-border);
 }
 
-.zorai-todo-context-item strong {
+.zorai-todo-context-item > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.zorai-todo-context-title {
   display: block;
+  color: var(--zorai-text);
   font-size: var(--text-sm);
   line-height: 1.45;
   word-break: break-word;
 }
 
-.zorai-todo-context-item span:not(.zorai-todo-checkbox) {
+.zorai-todo-context-status {
   color: var(--zorai-muted);
   font-size: var(--text-sm);
 }

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zor-ai",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://zorai.app",


### PR DESCRIPTION
Merge develop into main for v0.9.41.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect when follow-up messages are sent relative to daemon turns and tool execution—behavioral risk in the agent chat path, though covered by new unit tests.
> 
> **Overview**
> **Release v0.9.41** bumps workspace and package versions across Rust crates, frontend, and npm metadata.
> 
> **Thread turn lifecycle** introduces `threadTurnState` so “turn still active” covers **in-flight tool calls** (`requested` / `executing`), not only assistant `isStreaming`. The chat panel, stop/abort, daemon `done`/`error` handlers, and queued composer follow-ups use this so **send-now and queue dispatch** do not run on a still-running daemon turn or stay blocked by stale streaming placeholders. Stop/finalize also marks open tools as **error** with `(stopped)` and clears leftover streaming flags.
> 
> **Native thread messages** add hover actions: **copy**, **thumb up/down feedback**, **regenerate** (re-sends prior user text), and **delete**, wired from `ThreadsView` through the runtime.
> 
> **Daemon send** only builds local **context message payloads** when the thread is not yet linked to a daemon thread id.
> 
> **UI polish**: new `--text-sm-plus` token; chat tool rows and markdown sizing; thread list/todo context/composer typography; message action bar reveal on hover; operations and activity row presentation tweaks; boot splash wordmark styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d83aee87fafd3be37456a24b7271915be41a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->