### PR TITLE
Release v0.9.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9690,7 +9690,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zorai-cli"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-daemon"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-gateway"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "anyhow",
  "futures",
@@ -9800,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-mcp"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9819,7 +9819,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-protocol"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -9837,14 +9837,14 @@ dependencies = [
 
 [[package]]
 name = "zorai-shared"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "zorai-tui"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.41"
+version = "0.9.42"
 edition = "2021"
 license = "MIT"
 authors = ["zorai contributors"]

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -75,7 +75,7 @@ Minimal example:
 ```json
 {
   "name": "zorai-plugin-example",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "zoraiPlugin": {
     "entry": "dist/zorai-plugin.js",
     "format": "script"
@@ -102,7 +102,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.9.41",
+  version: "0.9.42",
   components: {
     ExamplePanel,
   },

--- a/frontend/electron/main.cjs
+++ b/frontend/electron/main.cjs
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu, clipboard, ipcMain, screen, shell, session } = require('electron');
+const { app, BrowserWindow, Menu, clipboard, ipcMain, nativeImage, screen, shell, session } = require('electron');
 const { spawn, spawnSync } = require('child_process');
 const path = require('path');
 const net = require('net');
@@ -90,6 +90,7 @@ const windowRuntime = createWindowRuntime({
     app,
     BrowserWindow,
     Menu,
+    nativeImage,
     electronDir: __dirname,
     getMainWindow: () => mainWindow,
     logToFile,

--- a/frontend/electron/main/window-runtime.cjs
+++ b/frontend/electron/main/window-runtime.cjs
@@ -1,3 +1,20 @@
+function resolveWindowFrameOptions(platform = process.platform) {
+    const useNativeFrame = platform === 'win32' || platform === 'linux';
+    return {
+        frame: useNativeFrame,
+        titleBarStyle: useNativeFrame ? 'default' : 'hidden',
+    };
+}
+
+function loadWindowIcon(options) {
+    const iconPath = resolveWindowIcon(options);
+    const icon = options.nativeImage.createFromPath(iconPath);
+    if (icon.isEmpty()) {
+        throw new Error(`Failed to load Electron window icon: ${iconPath}`);
+    }
+    return icon;
+}
+
 function resolveWindowIcon(options) {
     const {
         electronDir,
@@ -14,6 +31,7 @@ function createWindowRuntime(options) {
         app,
         BrowserWindow,
         Menu,
+        nativeImage,
         getMainWindow,
         logToFile,
         path,
@@ -82,16 +100,14 @@ function createWindowRuntime(options) {
 
     function createWindow() {
         const { width: screenW, height: screenH } = screen.getPrimaryDisplay().workAreaSize;
-        const useNativeFrame = process.platform === 'win32';
+        const frameOptions = resolveWindowFrameOptions();
         const mainWindow = new BrowserWindow({
             width: Math.min(1400, screenW),
             height: Math.min(900, screenH),
             minWidth: 600,
             minHeight: 400,
-            frame: useNativeFrame,
-            titleBarStyle: useNativeFrame ? 'default' : 'hidden',
+            ...frameOptions,
             autoHideMenuBar: false,
-            titleBarOverlay: useNativeFrame ? undefined : process.platform === 'win32' ? { color: '#181825', symbolColor: '#cdd6f4', height: 36 } : undefined,
             webPreferences: {
                 preload: path.join(options.electronDir, 'preload.cjs'),
                 nodeIntegration: false,
@@ -99,8 +115,9 @@ function createWindowRuntime(options) {
                 webviewTag: true,
             },
             title: appName,
-            icon: resolveWindowIcon({
+            icon: loadWindowIcon({
                 electronDir: options.electronDir,
+                nativeImage,
                 path,
             }),
             backgroundColor: '#1e1e2e',
@@ -142,4 +159,4 @@ function createWindowRuntime(options) {
     return { createWindow, setWindowOpacity };
 }
 
-module.exports = { createWindowRuntime, resolveWindowIcon };
+module.exports = { createWindowRuntime, loadWindowIcon, resolveWindowFrameOptions, resolveWindowIcon };

--- a/frontend/electron/packaged-icons.test.cjs
+++ b/frontend/electron/packaged-icons.test.cjs
@@ -1,0 +1,44 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const frontendDir = path.join(__dirname, "..");
+const packageConfig = JSON.parse(
+    fs.readFileSync(path.join(frontendDir, "package.json"), "utf8"),
+);
+
+function includedBuildFiles() {
+    return Array.isArray(packageConfig.build?.files) ? packageConfig.build.files : [];
+}
+
+test("Electron packages the runtime window icons", () => {
+    const files = includedBuildFiles();
+
+    assert.ok(
+        files.includes("assets/icon.png"),
+        "Linux BrowserWindow icon must be included in app.asar",
+    );
+    assert.ok(
+        files.includes("assets/icon.ico"),
+        "Windows BrowserWindow icon must be included in app.asar",
+    );
+});
+
+test("configured platform icons exist and are package inputs", () => {
+    const files = includedBuildFiles();
+    const platformIcons = [
+        packageConfig.build?.linux?.icon,
+        packageConfig.build?.win?.icon,
+        packageConfig.build?.mac?.icon,
+    ];
+
+    for (const icon of platformIcons) {
+        assert.equal(typeof icon, "string");
+        assert.ok(fs.existsSync(path.join(frontendDir, icon)), `${icon} must exist`);
+    }
+
+    for (const runtimeIcon of ["assets/icon.png", "assets/icon.ico"]) {
+        assert.ok(files.includes(runtimeIcon), `${runtimeIcon} must be packaged for runtime use`);
+    }
+});

--- a/frontend/electron/window-icon.test.cjs
+++ b/frontend/electron/window-icon.test.cjs
@@ -2,7 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("node:path");
 
-const { resolveWindowIcon } = require("./main/window-runtime.cjs");
+const { loadWindowIcon, resolveWindowFrameOptions, resolveWindowIcon } = require("./main/window-runtime.cjs");
 
 test("Linux windows use the PNG app icon", () => {
     assert.equal(
@@ -16,4 +16,59 @@ test("Windows windows use the ICO app icon", () => {
         resolveWindowIcon({ electronDir: "/repo/frontend/electron", path, platform: "win32" }),
         "/repo/frontend/assets/icon.ico",
     );
+});
+
+test("runtime icon is loaded into an Electron NativeImage", () => {
+    const loadedImage = { isEmpty: () => false };
+    let loadedPath = null;
+    const nativeImage = {
+        createFromPath(iconPath) {
+            loadedPath = iconPath;
+            return loadedImage;
+        },
+    };
+
+    assert.equal(
+        loadWindowIcon({
+            electronDir: "/repo/frontend/electron",
+            nativeImage,
+            path,
+            platform: "linux",
+        }),
+        loadedImage,
+    );
+    assert.equal(loadedPath, "/repo/frontend/assets/icon.png");
+});
+
+test("runtime icon loading fails loudly for an empty image", () => {
+    assert.throws(
+        () => loadWindowIcon({
+            electronDir: "/repo/frontend/electron",
+            nativeImage: { createFromPath: () => ({ isEmpty: () => true }) },
+            path,
+            platform: "linux",
+        }),
+        /Failed to load Electron window icon.*icon\.png/,
+    );
+});
+
+test("Linux windows use native window-manager chrome", () => {
+    assert.deepEqual(resolveWindowFrameOptions("linux"), {
+        frame: true,
+        titleBarStyle: "default",
+    });
+});
+
+test("Windows keeps its native window frame", () => {
+    assert.deepEqual(resolveWindowFrameOptions("win32"), {
+        frame: true,
+        titleBarStyle: "default",
+    });
+});
+
+test("macOS preserves its existing hidden title bar", () => {
+    assert.deepEqual(resolveWindowFrameOptions("darwin"), {
+        frame: false,
+        titleBarStyle: "hidden",
+    });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zorai",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zorai",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,9 @@
     },
     "files": [
       "dist/**/*",
-      "electron/**/*"
+      "electron/**/*",
+      "assets/icon.png",
+      "assets/icon.ico"
     ],
     "extraResources": [
       {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zorai",
   "private": true,
-  "version": "0.9.41",
+  "version": "0.9.42",
   "description": "Daemon-first agentic runtime with AI-native workflows",
   "homepage": "https://zorai.app",
   "author": {

--- a/frontend/scripts/dev-electron.cjs
+++ b/frontend/scripts/dev-electron.cjs
@@ -1,10 +1,19 @@
 const { spawn } = require("node:child_process");
 const path = require("node:path");
+const { installLinuxDevLauncher } = require("./linux-dev-launcher.cjs");
 
+const frontendDir = path.join(__dirname, "..");
 const electronBinary = require("electron");
 
+try {
+    installLinuxDevLauncher({ electronBinary, frontendDir });
+} catch (error) {
+    console.error("[zorai] Failed to install the Linux development launcher:", error?.message || String(error));
+    process.exit(1);
+}
+
 const child = spawn(electronBinary, ["."], {
-    cwd: path.join(__dirname, ".."),
+    cwd: frontendDir,
     stdio: "inherit",
     env: {
         ...process.env,

--- a/frontend/scripts/linux-dev-launcher.cjs
+++ b/frontend/scripts/linux-dev-launcher.cjs
@@ -1,0 +1,63 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+function escapeDesktopEntryValue(value) {
+    return String(value)
+        .replaceAll("\\", "\\\\")
+        .replaceAll("\n", "\\n")
+        .replaceAll("\r", "\\r")
+        .replaceAll("\t", "\\t")
+        .replaceAll(" ", "\\s");
+}
+
+function resolveLinuxDevLauncherPaths(options = {}) {
+    const frontendDir = path.resolve(options.frontendDir || path.join(__dirname, ".."));
+    const homeDir = options.homeDir || os.homedir();
+    return {
+        desktopFile: path.join(homeDir, ".local", "share", "applications", "zorai.desktop"),
+        electronBinary: options.electronBinary || path.join(frontendDir, "node_modules", "electron", "dist", "electron"),
+        icon: path.join(frontendDir, "assets", "icon.png"),
+    };
+}
+
+function createLinuxDesktopEntry(options) {
+    const electronBinary = escapeDesktopEntryValue(options.electronBinary);
+    const frontendDir = escapeDesktopEntryValue(options.frontendDir);
+    const icon = escapeDesktopEntryValue(options.icon);
+    return [
+        "[Desktop Entry]",
+        "Name=Zorai (Development)",
+        "Comment=Zorai Electron development application",
+        `Exec=${electronBinary} ${frontendDir}`,
+        `Icon=${icon}`,
+        "Terminal=false",
+        "Type=Application",
+        "StartupWMClass=zorai",
+        "Categories=Development;",
+        "NoDisplay=true",
+        "",
+    ].join("\n");
+}
+
+function installLinuxDevLauncher(options = {}) {
+    if (process.platform !== "linux" && !options.force) return null;
+    const frontendDir = path.resolve(options.frontendDir || path.join(__dirname, ".."));
+    const paths = resolveLinuxDevLauncherPaths({ ...options, frontendDir });
+    if (!fs.existsSync(paths.icon)) {
+        throw new Error(`Zorai development icon does not exist: ${paths.icon}`);
+    }
+    const entry = createLinuxDesktopEntry({ ...paths, frontendDir });
+    fs.mkdirSync(path.dirname(paths.desktopFile), { recursive: true });
+    if (!fs.existsSync(paths.desktopFile) || fs.readFileSync(paths.desktopFile, "utf8") !== entry) {
+        fs.writeFileSync(paths.desktopFile, entry, { encoding: "utf8", mode: 0o644 });
+    }
+    return paths.desktopFile;
+}
+
+module.exports = {
+    createLinuxDesktopEntry,
+    escapeDesktopEntryValue,
+    installLinuxDevLauncher,
+    resolveLinuxDevLauncherPaths,
+};

--- a/frontend/scripts/linux-dev-launcher.cjs
+++ b/frontend/scripts/linux-dev-launcher.cjs
@@ -2,34 +2,53 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-function escapeDesktopEntryValue(value) {
+const PACKAGED_DESKTOP_FILE = "zorai.desktop";
+const DEVELOPMENT_DESKTOP_FILE = "zorai-development.desktop";
+
+function escapeDesktopString(value) {
     return String(value)
         .replaceAll("\\", "\\\\")
         .replaceAll("\n", "\\n")
         .replaceAll("\r", "\\r")
-        .replaceAll("\t", "\\t")
-        .replaceAll(" ", "\\s");
+        .replaceAll("\t", "\\t");
+}
+
+function escapeDesktopEntryValue(value) {
+    return escapeDesktopString(value).replaceAll(" ", "\\s");
+}
+
+function quoteDesktopExecArgument(value) {
+    const escaped = String(value)
+        .replaceAll("\\", "\\\\")
+        .replaceAll("\"", "\\\"")
+        .replaceAll("`", "\\`")
+        .replaceAll("$", "\\$");
+    return `"${escaped}"`;
+}
+
+function formatDesktopExec(argv) {
+    return escapeDesktopString(argv.map(quoteDesktopExecArgument).join(" "));
 }
 
 function resolveLinuxDevLauncherPaths(options = {}) {
     const frontendDir = path.resolve(options.frontendDir || path.join(__dirname, ".."));
     const homeDir = options.homeDir || os.homedir();
     return {
-        desktopFile: path.join(homeDir, ".local", "share", "applications", "zorai.desktop"),
+        desktopFile: path.join(homeDir, ".local", "share", "applications", DEVELOPMENT_DESKTOP_FILE),
+        packagedDesktopFile: path.join(homeDir, ".local", "share", "applications", PACKAGED_DESKTOP_FILE),
         electronBinary: options.electronBinary || path.join(frontendDir, "node_modules", "electron", "dist", "electron"),
         icon: path.join(frontendDir, "assets", "icon.png"),
     };
 }
 
 function createLinuxDesktopEntry(options) {
-    const electronBinary = escapeDesktopEntryValue(options.electronBinary);
-    const frontendDir = escapeDesktopEntryValue(options.frontendDir);
+    const exec = formatDesktopExec([options.electronBinary, options.frontendDir]);
     const icon = escapeDesktopEntryValue(options.icon);
     return [
         "[Desktop Entry]",
         "Name=Zorai (Development)",
         "Comment=Zorai Electron development application",
-        `Exec=${electronBinary} ${frontendDir}`,
+        `Exec=${exec}`,
         `Icon=${icon}`,
         "Terminal=false",
         "Type=Application",
@@ -38,6 +57,17 @@ function createLinuxDesktopEntry(options) {
         "NoDisplay=true",
         "",
     ].join("\n");
+}
+
+function isDevelopmentDesktopEntry(contents) {
+    return contents.includes("Name=Zorai (Development)");
+}
+
+function removeShadowingDevelopmentLauncher(packagedDesktopFile) {
+    if (!fs.existsSync(packagedDesktopFile)) return;
+    const contents = fs.readFileSync(packagedDesktopFile, "utf8");
+    if (!isDevelopmentDesktopEntry(contents)) return;
+    fs.unlinkSync(packagedDesktopFile);
 }
 
 function installLinuxDevLauncher(options = {}) {
@@ -52,6 +82,7 @@ function installLinuxDevLauncher(options = {}) {
     if (!fs.existsSync(paths.desktopFile) || fs.readFileSync(paths.desktopFile, "utf8") !== entry) {
         fs.writeFileSync(paths.desktopFile, entry, { encoding: "utf8", mode: 0o644 });
     }
+    removeShadowingDevelopmentLauncher(paths.packagedDesktopFile);
     return paths.desktopFile;
 }
 

--- a/frontend/scripts/linux-dev-launcher.test.cjs
+++ b/frontend/scripts/linux-dev-launcher.test.cjs
@@ -1,9 +1,12 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const {
     createLinuxDesktopEntry,
+    installLinuxDevLauncher,
     resolveLinuxDevLauncherPaths,
 } = require("./linux-dev-launcher.cjs");
 
@@ -14,7 +17,8 @@ test("Linux dev launcher matches the Electron window identity", () => {
     });
 
     assert.deepEqual(paths, {
-        desktopFile: "/home/dev/.local/share/applications/zorai.desktop",
+        desktopFile: "/home/dev/.local/share/applications/zorai-development.desktop",
+        packagedDesktopFile: "/home/dev/.local/share/applications/zorai.desktop",
         electronBinary: "/repo/frontend/node_modules/electron/dist/electron",
         icon: "/repo/frontend/assets/icon.png",
     });
@@ -28,18 +32,75 @@ test("Linux dev launcher matches the Electron window identity", () => {
     assert.match(entry, /^Name=Zorai \(Development\)$/m);
     assert.match(entry, /^Icon=\/repo\/frontend\/assets\/icon\.png$/m);
     assert.match(entry, /^StartupWMClass=zorai$/m);
-    assert.match(entry, /^Exec=\/repo\/frontend\/node_modules\/electron\/dist\/electron \/repo\/frontend$/m);
+    assert.match(entry, /^Exec="\/repo\/frontend\/node_modules\/electron\/dist\/electron" "\/repo\/frontend"$/m);
     assert.match(entry, /^NoDisplay=true$/m);
 });
 
-test("Linux dev launcher escapes reserved desktop-entry characters", () => {
+test("Linux dev launcher quotes Exec arguments so spaces survive parsing", () => {
+    // Why: desktop files unescape \s to a space before splitting Exec. A path
+    // encoded with \s is then extra argv, not one command and one app directory.
     const entry = createLinuxDesktopEntry({
-        desktopFile: "/tmp/zorai.desktop",
+        desktopFile: "/tmp/zorai-development.desktop",
         electronBinary: "/repo/Electron Dev/electron",
         frontendDir: "/repo/Zorai Dev",
         icon: "/repo/Zorai Dev/icon.png",
     });
 
     assert.match(entry, /^Icon=\/repo\/Zorai\\sDev\/icon\.png$/m);
-    assert.match(entry, /^Exec=\/repo\/Electron\\sDev\/electron \/repo\/Zorai\\sDev$/m);
+    assert.match(entry, /^Exec="\/repo\/Electron Dev\/electron" "\/repo\/Zorai Dev"$/m);
+    assert.doesNotMatch(entry, /Exec=.*\\s/);
+});
+
+test("install writes a development-specific desktop id and leaves packaged zorai.desktop alone", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "zorai-launcher-"));
+    const frontendDir = path.join(homeDir, "frontend");
+    const icon = path.join(frontendDir, "assets", "icon.png");
+    const applicationsDir = path.join(homeDir, ".local", "share", "applications");
+    const packagedDesktopFile = path.join(applicationsDir, "zorai.desktop");
+    const packagedEntry = "[Desktop Entry]\nName=zorai\nExec=/usr/bin/zorai\n";
+
+    fs.mkdirSync(path.dirname(icon), { recursive: true });
+    fs.writeFileSync(icon, "png");
+    fs.mkdirSync(applicationsDir, { recursive: true });
+    fs.writeFileSync(packagedDesktopFile, packagedEntry);
+
+    const desktopFile = installLinuxDevLauncher({
+        force: true,
+        homeDir,
+        frontendDir,
+        electronBinary: "/usr/bin/electron",
+    });
+
+    assert.equal(desktopFile, path.join(applicationsDir, "zorai-development.desktop"));
+    assert.equal(fs.readFileSync(packagedDesktopFile, "utf8"), packagedEntry);
+    assert.match(fs.readFileSync(desktopFile, "utf8"), /^Name=Zorai \(Development\)$/m);
+});
+
+test("install removes a leftover development entry that was written as zorai.desktop", () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "zorai-launcher-"));
+    const frontendDir = path.join(homeDir, "frontend");
+    const icon = path.join(frontendDir, "assets", "icon.png");
+    const applicationsDir = path.join(homeDir, ".local", "share", "applications");
+    const packagedDesktopFile = path.join(applicationsDir, "zorai.desktop");
+
+    fs.mkdirSync(path.dirname(icon), { recursive: true });
+    fs.writeFileSync(icon, "png");
+    fs.mkdirSync(applicationsDir, { recursive: true });
+    fs.writeFileSync(packagedDesktopFile, [
+        "[Desktop Entry]",
+        "Name=Zorai (Development)",
+        "Exec=/repo/frontend/node_modules/electron/dist/electron /repo/frontend",
+        "NoDisplay=true",
+        "",
+    ].join("\n"));
+
+    installLinuxDevLauncher({
+        force: true,
+        homeDir,
+        frontendDir,
+        electronBinary: "/usr/bin/electron",
+    });
+
+    assert.equal(fs.existsSync(packagedDesktopFile), false);
+    assert.equal(fs.existsSync(path.join(applicationsDir, "zorai-development.desktop")), true);
 });

--- a/frontend/scripts/linux-dev-launcher.test.cjs
+++ b/frontend/scripts/linux-dev-launcher.test.cjs
@@ -1,0 +1,45 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const {
+    createLinuxDesktopEntry,
+    resolveLinuxDevLauncherPaths,
+} = require("./linux-dev-launcher.cjs");
+
+test("Linux dev launcher matches the Electron window identity", () => {
+    const paths = resolveLinuxDevLauncherPaths({
+        frontendDir: "/repo/frontend",
+        homeDir: "/home/dev",
+    });
+
+    assert.deepEqual(paths, {
+        desktopFile: "/home/dev/.local/share/applications/zorai.desktop",
+        electronBinary: "/repo/frontend/node_modules/electron/dist/electron",
+        icon: "/repo/frontend/assets/icon.png",
+    });
+
+    const entry = createLinuxDesktopEntry({
+        ...paths,
+        frontendDir: "/repo/frontend",
+    });
+
+    assert.match(entry, /^\[Desktop Entry\]$/m);
+    assert.match(entry, /^Name=Zorai \(Development\)$/m);
+    assert.match(entry, /^Icon=\/repo\/frontend\/assets\/icon\.png$/m);
+    assert.match(entry, /^StartupWMClass=zorai$/m);
+    assert.match(entry, /^Exec=\/repo\/frontend\/node_modules\/electron\/dist\/electron \/repo\/frontend$/m);
+    assert.match(entry, /^NoDisplay=true$/m);
+});
+
+test("Linux dev launcher escapes reserved desktop-entry characters", () => {
+    const entry = createLinuxDesktopEntry({
+        desktopFile: "/tmp/zorai.desktop",
+        electronBinary: "/repo/Electron Dev/electron",
+        frontendDir: "/repo/Zorai Dev",
+        icon: "/repo/Zorai Dev/icon.png",
+    });
+
+    assert.match(entry, /^Icon=\/repo\/Zorai\\sDev\/icon\.png$/m);
+    assert.match(entry, /^Exec=\/repo\/Electron\\sDev\/electron \/repo\/Zorai\\sDev$/m);
+});

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -4,6 +4,10 @@ import { useWorkspaceStore } from "../lib/workspaceStore";
 import { useSettingsStore } from "../lib/settingsStore";
 import { useKeybindStore } from "../lib/keybindStore";
 import { BUILTIN_THEMES } from "../lib/themes";
+import { handleZoraiAppCommand } from "../zorai/shell/zoraiAppCommands";
+import { navigateZorai } from "../zorai/shell/zoraiNavigationEvents";
+import { zoraiNavItems } from "../zorai/shell/navigation";
+import { zoraiTools } from "../zorai/features/tools/tools";
 import { CommandPaletteHeader } from "./command-palette/CommandPaletteHeader";
 import { CommandPaletteResults } from "./command-palette/CommandPaletteResults";
 import type { Command, CommandPaletteProps } from "./command-palette/shared";
@@ -11,27 +15,6 @@ import type { Command, CommandPaletteProps } from "./command-palette/shared";
 export function CommandPalette({ style, className }: CommandPaletteProps = {}) {
   const open = useWorkspaceStore((s) => s.commandPaletteOpen);
   const toggle = useWorkspaceStore((s) => s.toggleCommandPalette);
-  const splitActive = useWorkspaceStore((s) => s.splitActive);
-  const createSurface = useWorkspaceStore((s) => s.createSurface);
-  const closeSurface = useWorkspaceStore((s) => s.closeSurface);
-  const createWorkspace = useWorkspaceStore((s) => s.createWorkspace);
-  const activePaneId = useWorkspaceStore((s) => s.activePaneId);
-  const closePane = useWorkspaceStore((s) => s.closePane);
-  const toggleZoom = useWorkspaceStore((s) => s.toggleZoom);
-  const toggleSidebar = useWorkspaceStore((s) => s.toggleSidebar);
-  const toggleNotificationPanel = useWorkspaceStore((s) => s.toggleNotificationPanel);
-  const toggleSettings = useWorkspaceStore((s) => s.toggleSettings);
-  const toggleSessionVault = useWorkspaceStore((s) => s.toggleSessionVault);
-  const toggleCommandLog = useWorkspaceStore((s) => s.toggleCommandLog);
-  const toggleSearch = useWorkspaceStore((s) => s.toggleSearch);
-  const toggleSnippetPicker = useWorkspaceStore((s) => s.toggleSnippetPicker);
-  const toggleAgentPanel = useWorkspaceStore((s) => s.toggleAgentPanel);
-  const toggleCommandHistory = useWorkspaceStore((s) => s.toggleCommandHistory);
-  const toggleSystemMonitor = useWorkspaceStore((s) => s.toggleSystemMonitor);
-  const toggleCanvas = useWorkspaceStore((s) => s.toggleCanvas);
-  const toggleTimeTravel = useWorkspaceStore((s) => s.toggleTimeTravel);
-  const applyPresetLayout = useWorkspaceStore((s) => s.applyPresetLayout);
-  const activeSurface = useWorkspaceStore((s) => s.activeSurface());
   const updateSetting = useSettingsStore((s) => s.updateSetting);
   const settings = useSettingsStore((s) => s.settings);
   const bindings = useKeybindStore((s) => s.bindings);
@@ -51,33 +34,25 @@ export function CommandPalette({ style, className }: CommandPaletteProps = {}) {
   };
 
   const commands: Command[] = [
-    { id: "split-h", label: "Split Horizontal", category: "Layout", shortcut: shortcutFor("splitHorizontal"), action: () => splitActive("horizontal") },
-    { id: "split-v", label: "Split Vertical", category: "Layout", shortcut: shortcutFor("splitVertical"), action: () => splitActive("vertical") },
-    { id: "close-pane", label: "Close Active Pane", category: "Layout", shortcut: shortcutFor("closePane"), action: () => { const id = activePaneId(); if (id) closePane(id); } },
-    { id: "zoom-pane", label: "Toggle Zoom Pane", category: "Layout", shortcut: shortcutFor("toggleZoom"), action: toggleZoom },
-    { id: "layout-single", label: "Layout: Single Pane", category: "Layout", action: () => applyPresetLayout("single") },
-    { id: "layout-2col", label: "Layout: 2 Columns", category: "Layout", action: () => applyPresetLayout("2-columns") },
-    { id: "layout-3col", label: "Layout: 3 Columns", category: "Layout", action: () => applyPresetLayout("3-columns") },
-    { id: "layout-grid", label: "Layout: Grid 2×2", category: "Layout", action: () => applyPresetLayout("grid-2x2") },
-    { id: "layout-main-stack", label: "Layout: Main + Stack", category: "Layout", action: () => applyPresetLayout("main-stack") },
-    { id: "new-surface", label: "New Surface", category: "Surface", shortcut: shortcutFor("newSurface"), action: () => createSurface() },
-    { id: "close-surface", label: "Close Surface", category: "Surface", shortcut: shortcutFor("closeSurface"), action: () => { if (activeSurface) closeSurface(activeSurface.id); } },
-    { id: "new-workspace", label: "New Workspace", category: "Workspace", shortcut: shortcutFor("newWorkspace"), action: () => createWorkspace() },
-    { id: "toggle-sidebar", label: "Toggle Sidebar", category: "View", shortcut: shortcutFor("toggleSidebar"), action: toggleSidebar },
-    { id: "notifications", label: "Notifications", category: "View", shortcut: shortcutFor("toggleNotifications"), action: toggleNotificationPanel },
-    { id: "settings", label: "Settings", category: "View", shortcut: shortcutFor("toggleSettings"), action: toggleSettings },
-    { id: "session-vault", label: "Session Vault", category: "View", shortcut: shortcutFor("toggleSessionVault"), action: toggleSessionVault },
-    { id: "command-log", label: "Command Log", category: "View", shortcut: shortcutFor("toggleCommandLog"), action: toggleCommandLog },
-    { id: "find-in-buffer", label: "Find in Buffer", category: "View", shortcut: shortcutFor("toggleSearch"), action: toggleSearch },
-    { id: "snippets", label: "Snippets", category: "Agent", shortcut: shortcutFor("toggleSnippets"), action: toggleSnippetPicker },
-    { id: "agent-panel", label: "Mission Console", category: "Agent", shortcut: shortcutFor("toggleAgentPanel"), action: toggleAgentPanel },
+    ...zoraiNavItems.map((item) => ({
+      id: `view-${item.id}`,
+      label: item.label,
+      category: "Navigate",
+      action: () => navigateZorai({ view: item.id }),
+    })),
+    { id: "new-thread", label: "New Thread", category: "Threads", shortcut: shortcutFor("newSurface"), action: () => { handleZoraiAppCommand("new-surface"); } },
+    { id: "search-threads", label: "Search Threads", category: "Threads", shortcut: shortcutFor("toggleSearch"), action: () => { handleZoraiAppCommand("toggle-search"); } },
+    { id: "toggle-context", label: "Toggle Context Panel", category: "View", shortcut: shortcutFor("toggleSidebar"), action: () => { handleZoraiAppCommand("toggle-sidebar"); } },
+    ...zoraiTools.map((tool) => ({
+      id: `tool-${tool.id}`,
+      label: tool.title,
+      category: "Tools",
+      action: () => navigateZorai({ view: "tools" as const, tool: tool.id }),
+    })),
+    { id: "about", label: "About", category: "View", action: () => { handleZoraiAppCommand("about"); } },
     { id: "image-prompt", label: "🖼 Image Prompt", category: "Agent", action: () => composeImagePrompt() },
-    { id: "command-history", label: "Command History", category: "Agent", shortcut: shortcutFor("toggleCommandHistory"), action: toggleCommandHistory },
-    { id: "system-monitor", label: "System Monitor", category: "View", shortcut: shortcutFor("toggleSystemMonitor"), action: toggleSystemMonitor },
-    { id: "execution-canvas", label: "Execution Canvas", category: "View", shortcut: shortcutFor("toggleCanvas"), action: toggleCanvas },
-    { id: "time-travel", label: "Time Travel Snapshots", category: "View", shortcut: shortcutFor("toggleTimeTravel"), action: toggleTimeTravel },
-    { id: "verify-integrity", label: "Verify WORM Integrity", category: "Infrastructure", action: () => { (getBridge())?.verifyIntegrity?.(); } },
-    { id: "generate-skill", label: "Generate Skill from History", category: "Infrastructure", action: toggleAgentPanel },
+    { id: "time-travel", label: "Time Travel Snapshots", category: "View", shortcut: shortcutFor("toggleTimeTravel"), action: () => { handleZoraiAppCommand("toggle-time-travel"); } },
+    { id: "verify-integrity", label: "Verify WORM Integrity", category: "Infrastructure", action: () => { getBridge()?.verifyIntegrity?.(); } },
     { id: "toggle-sandbox", label: "Toggle Sandbox", category: "Infrastructure", action: () => updateSetting("sandboxEnabled", !settings.sandboxEnabled) },
     ...BUILTIN_THEMES.map((theme) => ({
       id: `theme-${theme.name}`,

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -58,7 +58,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>Zorai - Agent Orchestration Workspace</p>
-                    <p>Version 0.9.41</p>
+                    <p>Version 0.9.42</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A thread-first agent orchestration workspace with durable goals, workspace boards,
                         approvals, tools, and daemon-backed runtime state.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.9.41",
+        version: "0.9.42",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.9.41",
+        version: "0.9.42",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/zorai/ZoraiApp.tsx
+++ b/frontend/src/zorai/ZoraiApp.tsx
@@ -4,7 +4,9 @@ import { AgentChatPanelProvider } from "@/components/agent-chat-panel/runtime";
 import { ConciergeToast } from "@/components/ConciergeToast";
 import { OperatorProfileOnboardingPanel } from "@/components/OperatorProfileOnboardingPanel";
 import { OperatorQuestionOverlay } from "@/components/OperatorQuestionOverlay";
+import { CommandPalette } from "@/components/CommandPalette";
 import { SetupOnboardingPanel } from "@/components/SetupOnboardingPanel";
+import { TimeTravelSlider } from "@/components/TimeTravelSlider";
 import { ToastViewport } from "@/components/ToastViewport";
 import { getBridge } from "@/lib/bridge";
 import { useAgentStore } from "@/lib/agentStore";
@@ -12,10 +14,12 @@ import { useAuditStore } from "@/lib/auditStore";
 import { useNotificationStore } from "@/lib/notificationStore";
 import { useWorkspaceStore } from "@/lib/workspaceStore";
 import { shouldAutoStartOperatorProfileFromConcierge } from "./conciergeEvents";
+import { useZoraiAppCommands } from "./shell/zoraiAppCommands";
 import { ZoraiShell } from "./shell/ZoraiShell";
 
 export function ZoraiApp() {
   const operatorProfileAutoStartRequested = useRef(false);
+  useZoraiAppCommands();
 
   useEffect(() => {
     useWorkspaceStore.setState({ agentPanelOpen: true });
@@ -85,6 +89,8 @@ export function ZoraiApp() {
   return (
     <AgentChatPanelProvider>
       <ZoraiShell />
+      <CommandPalette />
+      <TimeTravelSlider />
       <SetupOnboardingPanel />
       <OperatorProfileOnboardingPanel />
       <AgentApprovalOverlay />

--- a/frontend/src/zorai/features/settings/SettingsPanels.tsx
+++ b/frontend/src/zorai/features/settings/SettingsPanels.tsx
@@ -63,7 +63,7 @@ export const conciergeReasoningEffortOptions: Array<{ value: AgentSettings["reas
   { value: "xhigh", label: "xhigh" },
   { value: "max", label: "max" },
 ];
-const APP_VERSION = "0.9.41";
+const APP_VERSION = "0.9.42";
 const APP_AUTHOR = "Mariusz Kurman";
 const APP_GITHUB = "mkurman/zorai";
 const APP_HOMEPAGE = "zorai.app";

--- a/frontend/src/zorai/features/threads/ThreadsRail.tsx
+++ b/frontend/src/zorai/features/threads/ThreadsRail.tsx
@@ -15,6 +15,7 @@ import {
   type ThreadFilterTab,
 } from "./threadFilterModel";
 import { openThreadTarget } from "./openThreadTarget";
+import { ZORAI_FOCUS_SEARCH_EVENT, consumePendingFocusSearch } from "../../shell/zoraiNavigationEvents";
 
 const THREAD_FILTER_FETCH_DEBOUNCE_MS = 1000;
 
@@ -31,6 +32,7 @@ export function ThreadsRail() {
   const [loadingTab, setLoadingTab] = useState<ThreadFilterTab | null>(null);
   const pendingFetchIdRef = useRef(0);
   const loadedAgentFilterRef = useRef<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
   const goalThreadIdSet = useMemo(() => goalThreadIds(runtime.goalRunsForTrace), [runtime.goalRunsForTrace]);
   const daemonAgentFilter = useMemo(() => daemonAgentFilterForThreadTab(tab), [tab]);
   const fetchKey = daemonAgentFilter ?? "__all__";
@@ -67,6 +69,17 @@ export function ThreadsRail() {
   useEffect(() => {
     void refreshSubAgents();
   }, [refreshSubAgents]);
+
+  useEffect(() => {
+    const focusSearch = () => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    };
+    if (consumePendingFocusSearch()) focusSearch();
+    const onFocusSearch = () => focusSearch();
+    window.addEventListener(ZORAI_FOCUS_SEARCH_EVENT, onFocusSearch);
+    return () => window.removeEventListener(ZORAI_FOCUS_SEARCH_EVENT, onFocusSearch);
+  }, []);
 
   useEffect(() => {
     pendingFetchIdRef.current += 1;
@@ -131,7 +144,7 @@ export function ThreadsRail() {
         </button>
         <button type="button" className="zorai-ghost-button" onClick={refreshSelectedTab}>Refresh</button>
       </div>
-      <input className="zorai-search-input" value={runtime.searchQuery} onChange={(event) => runtime.setSearchQuery(event.target.value)} placeholder="Search threads" />
+      <input ref={searchInputRef} className="zorai-search-input" value={runtime.searchQuery} onChange={(event) => runtime.setSearchQuery(event.target.value)} placeholder="Search threads" />
       <div className="zorai-thread-filter-tabs" aria-label="Thread source filters">
         {fixedThreadTabs.map((item) => (
           <button

--- a/frontend/src/zorai/features/threads/ThreadsRail.tsx
+++ b/frontend/src/zorai/features/threads/ThreadsRail.tsx
@@ -76,7 +76,9 @@ export function ThreadsRail() {
       searchInputRef.current?.select();
     };
     if (consumePendingFocusSearch()) focusSearch();
-    const onFocusSearch = () => focusSearch();
+    const onFocusSearch = () => {
+      if (consumePendingFocusSearch()) focusSearch();
+    };
     window.addEventListener(ZORAI_FOCUS_SEARCH_EVENT, onFocusSearch);
     return () => window.removeEventListener(ZORAI_FOCUS_SEARCH_EVENT, onFocusSearch);
   }, []);

--- a/frontend/src/zorai/features/zoraiSurfaces.test.ts
+++ b/frontend/src/zorai/features/zoraiSurfaces.test.ts
@@ -530,4 +530,17 @@ describe("Zorai feature surfaces", () => {
     expect(source).toContain("openThreadTarget");
     expect(source).toContain("navigateZorai");
   });
+
+  it("routes the native window menu into current Zorai surfaces", () => {
+    const appSource = readFeature("../ZoraiApp.tsx");
+    const commandSource = readFeature("../shell/zoraiAppCommands.ts");
+    const shellSource = readFeature("../shell/ZoraiShell.tsx");
+
+    expect(appSource).toContain("useZoraiAppCommands");
+    expect(appSource).toContain("CommandPalette");
+    expect(commandSource).toContain("toggle-command-palette");
+    expect(commandSource).toContain("onAppCommand");
+    expect(shellSource).toContain("settingsTab");
+    expect(shellSource).toContain("toggleContext");
+  });
 });

--- a/frontend/src/zorai/features/zoraiSurfaces.test.ts
+++ b/frontend/src/zorai/features/zoraiSurfaces.test.ts
@@ -543,4 +543,17 @@ describe("Zorai feature surfaces", () => {
     expect(shellSource).toContain("settingsTab");
     expect(shellSource).toContain("toggleContext");
   });
+
+  it("consumes pending thread search focus when the live event is handled", () => {
+    // Why: Search while Threads is already open focuses via the delayed event and
+    // never remounts the rail. If that handler skips consumePendingFocusSearch,
+    // the next remount still auto-selects the search field.
+    const railSource = readFeature("./threads/ThreadsRail.tsx");
+    const handler = railSource.slice(
+      railSource.indexOf("const onFocusSearch"),
+      railSource.indexOf("window.addEventListener(ZORAI_FOCUS_SEARCH_EVENT"),
+    );
+
+    expect(handler).toContain("consumePendingFocusSearch");
+  });
 });

--- a/frontend/src/zorai/shell/ZoraiShell.tsx
+++ b/frontend/src/zorai/shell/ZoraiShell.tsx
@@ -40,6 +40,11 @@ export function ZoraiShell() {
       const detail = (event as CustomEvent<ZoraiNavigateDetail>).detail;
       if (detail.view) setActiveView(detail.view);
       if (detail.tool) setActiveTool(detail.tool);
+      if (detail.settingsTab) {
+        setActiveSettingsTab(detail.settingsTab);
+        if (!detail.view) setActiveView("settings");
+      }
+      if (detail.toggleContext) setContextOpen((current) => !current);
       if (detail.returnTarget !== undefined) setReturnTarget(detail.returnTarget);
       if (detail.goalRunId) {
         setGoalOpenRequest((current) => ({ id: detail.goalRunId ?? "", nonce: (current?.nonce ?? 0) + 1 }));

--- a/frontend/src/zorai/shell/zoraiAppCommands.test.ts
+++ b/frontend/src/zorai/shell/zoraiAppCommands.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { resolveZoraiAppCommand } from "./zoraiAppCommands";
+
+function menuCommandsFromWindowRuntime(): string[] {
+  const source = readFileSync(new URL("../../../electron/main/window-runtime.cjs", import.meta.url), "utf8");
+  return [...source.matchAll(/sendAppCommand\('([^']+)'\)/g)].map((match) => match[1]);
+}
+
+describe("Zorai window-frame app commands", () => {
+  it("opens the command palette instead of the old overlay-only toggle", () => {
+    expect(resolveZoraiAppCommand("toggle-command-palette")).toEqual({ kind: "palette" });
+  });
+
+  it("sends Search to the thread list instead of terminal buffer find", () => {
+    expect(resolveZoraiAppCommand("toggle-search")).toEqual({
+      kind: "navigate",
+      detail: { view: "threads", focusSearch: true },
+    });
+  });
+
+  it("maps leftover in-flight menu actions onto current Zorai surfaces", () => {
+    expect(resolveZoraiAppCommand("toggle-settings")).toEqual({
+      kind: "navigate",
+      detail: { view: "settings" },
+    });
+    expect(resolveZoraiAppCommand("about")).toEqual({
+      kind: "navigate",
+      detail: { view: "settings", settingsTab: "about" },
+    });
+    expect(resolveZoraiAppCommand("new-surface")).toEqual({ kind: "new-thread" });
+    expect(resolveZoraiAppCommand("toggle-file-manager")).toEqual({
+      kind: "navigate",
+      detail: { view: "tools", tool: "files" },
+    });
+    expect(resolveZoraiAppCommand("toggle-sidebar")).toEqual({
+      kind: "navigate",
+      detail: { toggleContext: true },
+    });
+  });
+
+  it("leaves terminal edit commands to the terminal listener", () => {
+    expect(resolveZoraiAppCommand("copy")).toEqual({ kind: "unhandled" });
+    expect(resolveZoraiAppCommand("paste")).toEqual({ kind: "unhandled" });
+    expect(resolveZoraiAppCommand("select-all")).toEqual({ kind: "unhandled" });
+  });
+
+  it("covers every Electron menu app-command except clipboard roles", () => {
+    const passthrough = new Set(["copy", "paste", "select-all"]);
+    for (const command of menuCommandsFromWindowRuntime()) {
+      const resolution = resolveZoraiAppCommand(command);
+      if (passthrough.has(command)) {
+        expect(resolution.kind, command).toBe("unhandled");
+        continue;
+      }
+      expect(resolution.kind, command).not.toBe("unhandled");
+    }
+  });
+});

--- a/frontend/src/zorai/shell/zoraiAppCommands.ts
+++ b/frontend/src/zorai/shell/zoraiAppCommands.ts
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+import { getBridge } from "@/lib/bridge";
+import { useAgentStore } from "@/lib/agentStore";
+import { useWorkspaceStore } from "@/lib/workspaceStore";
+import type { ZoraiNavigateDetail } from "./zoraiNavigationEvents";
+import { navigateZorai } from "./zoraiNavigationEvents";
+
+export type ZoraiAppCommandResolution =
+  | { kind: "unhandled" }
+  | { kind: "palette" }
+  | { kind: "time-travel" }
+  | { kind: "new-thread" }
+  | { kind: "navigate"; detail: ZoraiNavigateDetail };
+
+const MENU_COMMANDS: Record<string, ZoraiAppCommandResolution> = {
+  "toggle-command-palette": { kind: "palette" },
+  "toggle-search": { kind: "navigate", detail: { view: "threads", focusSearch: true } },
+  "toggle-settings": { kind: "navigate", detail: { view: "settings" } },
+  about: { kind: "navigate", detail: { view: "settings", settingsTab: "about" } },
+  "new-workspace": { kind: "navigate", detail: { view: "workspaces" } },
+  "new-surface": { kind: "new-thread" },
+  "toggle-sidebar": { kind: "navigate", detail: { toggleContext: true } },
+  "toggle-mission": { kind: "navigate", detail: { view: "threads" } },
+  "toggle-file-manager": { kind: "navigate", detail: { view: "tools", tool: "files" } },
+  "toggle-command-history": { kind: "navigate", detail: { view: "tools", tool: "history" } },
+  "toggle-command-log": { kind: "navigate", detail: { view: "tools", tool: "history" } },
+  "toggle-session-vault": { kind: "navigate", detail: { view: "tools", tool: "vault" } },
+  "toggle-system-monitor": { kind: "navigate", detail: { view: "tools", tool: "system" } },
+  "toggle-canvas": { kind: "navigate", detail: { view: "tools", tool: "canvas" } },
+  "split-right": { kind: "navigate", detail: { view: "tools", tool: "terminal" } },
+  "split-down": { kind: "navigate", detail: { view: "tools", tool: "terminal" } },
+  "toggle-zoom": { kind: "navigate", detail: { view: "tools", tool: "terminal" } },
+  "toggle-time-travel": { kind: "time-travel" },
+};
+
+export function resolveZoraiAppCommand(command: string): ZoraiAppCommandResolution {
+  return MENU_COMMANDS[command] ?? { kind: "unhandled" };
+}
+
+export function handleZoraiAppCommand(command: string): boolean {
+  const resolution = resolveZoraiAppCommand(command);
+  if (resolution.kind === "unhandled") {
+    return false;
+  }
+  if (resolution.kind === "palette") {
+    useWorkspaceStore.getState().toggleCommandPalette();
+    return true;
+  }
+  if (resolution.kind === "time-travel") {
+    useWorkspaceStore.getState().toggleTimeTravel();
+    return true;
+  }
+  if (resolution.kind === "new-thread") {
+    useAgentStore.getState().createThread({});
+    navigateZorai({ view: "threads" });
+    return true;
+  }
+  navigateZorai(resolution.detail);
+  return true;
+}
+
+export function useZoraiAppCommands() {
+  useEffect(() => {
+    const unsubscribe = getBridge()?.onAppCommand?.((command: string) => {
+      handleZoraiAppCommand(command);
+    });
+    return () => {
+      if (typeof unsubscribe === "function") unsubscribe();
+    };
+  }, []);
+}

--- a/frontend/src/zorai/shell/zoraiNavigationEvents.ts
+++ b/frontend/src/zorai/shell/zoraiNavigationEvents.ts
@@ -1,7 +1,9 @@
+import type { ZoraiSettingsTabId } from "../features/settings/settingsTabs";
 import type { ZoraiToolId } from "../features/tools/tools";
 import type { ZoraiViewId } from "./navigation";
 
 export const ZORAI_NAVIGATE_EVENT = "zorai-navigate";
+export const ZORAI_FOCUS_SEARCH_EVENT = "zorai-focus-search";
 
 export type ZoraiReturnTarget = {
   view: ZoraiViewId;
@@ -11,10 +13,27 @@ export type ZoraiReturnTarget = {
 export type ZoraiNavigateDetail = {
   view?: ZoraiViewId;
   tool?: ZoraiToolId;
+  settingsTab?: ZoraiSettingsTabId;
+  toggleContext?: boolean;
+  focusSearch?: boolean;
   returnTarget?: ZoraiReturnTarget | null;
   goalRunId?: string | null;
 };
 
+let pendingFocusSearch = false;
+
+export function consumePendingFocusSearch(): boolean {
+  if (!pendingFocusSearch) return false;
+  pendingFocusSearch = false;
+  return true;
+}
+
 export function navigateZorai(detail: ZoraiNavigateDetail) {
+  if (detail.focusSearch) pendingFocusSearch = true;
   window.dispatchEvent(new CustomEvent<ZoraiNavigateDetail>(ZORAI_NAVIGATE_EVENT, { detail }));
+  if (detail.focusSearch) {
+    window.setTimeout(() => {
+      window.dispatchEvent(new CustomEvent(ZORAI_FOCUS_SEARCH_EVENT));
+    }, 0);
+  }
 }

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zor-ai",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://zorai.app",


### PR DESCRIPTION
Merge develop into main for v0.9.42.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron window creation, packaged assets, and writes a Linux .desktop file under the user home during dev. Menu/command remapping can send native accelerators to the wrong surface if a mapping is off.
> 
> **Overview**
> **v0.9.42** plus desktop/shell alignment: native menus and the command palette now drive current Zorai views (threads, tools, settings, context panel) instead of the old overlay/layout commands.
> 
> Linux windows use native window-manager chrome. Runtime icons are loaded as `NativeImage` and packaged into the Electron asar. Dev Electron on Linux installs a hidden `zorai-development.desktop` launcher (quoted Exec paths, `StartupWMClass=zorai`) and removes leftover development entries that shadowed packaged `zorai.desktop`.
> 
> Search from the menu focuses the threads search field via a pending-focus handshake so it works whether Threads is already open or not. Clipboard menu actions stay on the terminal listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc9139a526a8aefdae7667d44696926216309ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->