### PR TITLE
Release v0.9.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9690,7 +9690,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zorai-cli"
-version = "0.9.43"
+version = "0.9.44"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-daemon"
-version = "0.9.43"
+version = "0.9.44"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-gateway"
-version = "0.9.43"
+version = "0.9.44"
 dependencies = [
  "anyhow",
  "futures",
@@ -9800,7 +9800,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-mcp"
-version = "0.9.43"
+version = "0.9.44"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9819,7 +9819,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-protocol"
-version = "0.9.43"
+version = "0.9.44"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -9837,14 +9837,14 @@ dependencies = [
 
 [[package]]
 name = "zorai-shared"
-version = "0.9.43"
+version = "0.9.44"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "zorai-tui"
-version = "0.9.43"
+version = "0.9.44"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.43"
+version = "0.9.44"
 edition = "2021"
 license = "MIT"
 authors = ["zorai contributors"]

--- a/crates/zorai-daemon/src/agent/engine.rs
+++ b/crates/zorai-daemon/src/agent/engine.rs
@@ -135,7 +135,7 @@ pub struct AgentEngine {
     pub thread_participant_suggestions: RwLock<HashMap<String, Vec<ThreadParticipantSuggestion>>>,
     pub(super) deferred_visible_thread_continuations:
         Mutex<HashMap<String, Vec<DeferredVisibleThreadContinuation>>>,
-    pub(super) active_visible_thread_continuation_flushes: Mutex<HashSet<String>>,
+    pub(super) active_visible_thread_continuation_flushes: std::sync::Mutex<HashSet<String>>,
     pub(super) active_thread_participant_suggestion_drains: Mutex<HashSet<String>>,
     pub thread_client_surfaces: RwLock<HashMap<String, zorai_protocol::ClientSurface>>,
     pub thread_execution_profiles: RwLock<HashMap<String, ThreadExecutionProfile>>,
@@ -399,7 +399,7 @@ impl AgentEngine {
             thread_participants: RwLock::new(HashMap::new()),
             thread_participant_suggestions: RwLock::new(HashMap::new()),
             deferred_visible_thread_continuations: Mutex::new(HashMap::new()),
-            active_visible_thread_continuation_flushes: Mutex::new(HashSet::new()),
+            active_visible_thread_continuation_flushes: std::sync::Mutex::new(HashSet::new()),
             active_thread_participant_suggestion_drains: Mutex::new(HashSet::new()),
             thread_client_surfaces: RwLock::new(HashMap::new()),
             thread_execution_profiles: RwLock::new(HashMap::new()),

--- a/crates/zorai-daemon/src/agent/goal_planner/progress.rs
+++ b/crates/zorai-daemon/src/agent/goal_planner/progress.rs
@@ -945,6 +945,13 @@ impl AgentEngine {
             lineage_digest,
         );
 
+        {
+            let goal_runs = self.goal_runs.lock().await;
+            if !goal_runs.iter().any(|item| item.id == snapshot.id) {
+                anyhow::bail!("goal run missing while queuing progress supervision");
+            }
+        }
+
         let supervision_task = self
             .enqueue_task(
                 format!("Progress supervision: {}", snapshot.title),
@@ -983,24 +990,41 @@ impl AgentEngine {
 
         let updated_goal = {
             let mut goal_runs = self.goal_runs.lock().await;
-            let Some(goal_run) = goal_runs.iter_mut().find(|item| item.id == snapshot.id) else {
-                anyhow::bail!("goal run missing while queuing progress supervision");
-            };
-            goal_run.updated_at = now_millis();
-            if !goal_run
-                .child_task_ids
-                .iter()
-                .any(|id| id == &updated_task.id)
+            goal_runs
+                .iter_mut()
+                .find(|item| item.id == snapshot.id)
+                .map(|goal_run| {
+                    goal_run.updated_at = now_millis();
+                    if !goal_run
+                        .child_task_ids
+                        .iter()
+                        .any(|id| id == &updated_task.id)
+                    {
+                        goal_run.child_task_ids.push(updated_task.id.clone());
+                    }
+                    goal_run.child_task_count = goal_run.child_task_ids.len() as u32;
+                    goal_run.events.push(make_goal_run_event(
+                        "progress_supervision",
+                        "stagnation detected; supervisor queued to propose alternative directions",
+                        Some(reason.to_string()),
+                    ));
+                    goal_run.clone()
+                })
+        };
+        let Some(updated_goal) = updated_goal else {
             {
-                goal_run.child_task_ids.push(updated_task.id.clone());
+                let mut tasks = self.tasks.lock().await;
+                tasks.retain(|task| task.id != updated_task.id);
             }
-            goal_run.child_task_count = goal_run.child_task_ids.len() as u32;
-            goal_run.events.push(make_goal_run_event(
-                "progress_supervision",
-                "stagnation detected; supervisor queued to propose alternative directions",
-                Some(reason.to_string()),
-            ));
-            goal_run.clone()
+            if let Err(error) = self.history.delete_agent_task(&updated_task.id).await {
+                tracing::warn!(
+                    task_id = %updated_task.id,
+                    error = %error,
+                    "failed to delete orphaned progress supervisor task"
+                );
+            }
+            self.persist_tasks().await;
+            anyhow::bail!("goal run missing while queuing progress supervision");
         };
 
         self.persist_tasks().await;

--- a/crates/zorai-daemon/src/agent/heartbeat_checks/tests.rs
+++ b/crates/zorai-daemon/src/agent/heartbeat_checks/tests.rs
@@ -134,7 +134,7 @@ async fn make_test_engine(
         thread_participants: RwLock::new(HashMap::new()),
         thread_participant_suggestions: RwLock::new(HashMap::new()),
         deferred_visible_thread_continuations: Mutex::new(HashMap::new()),
-        active_visible_thread_continuation_flushes: Mutex::new(HashSet::new()),
+        active_visible_thread_continuation_flushes: std::sync::Mutex::new(HashSet::new()),
         active_thread_participant_suggestion_drains: Mutex::new(HashSet::new()),
         thread_client_surfaces: RwLock::new(HashMap::new()),
         thread_execution_profiles: RwLock::new(HashMap::new()),

--- a/crates/zorai-daemon/src/agent/tests/goal_planner.rs
+++ b/crates/zorai-daemon/src/agent/tests/goal_planner.rs
@@ -5607,6 +5607,15 @@ async fn stagnation_pending_rolls_back_when_supervisor_enqueue_fails() {
         progress.consecutive_failures, 3,
         "a failed enqueue must keep the streak so the next review can still intervene"
     );
+    assert!(
+        engine
+            .tasks
+            .lock()
+            .await
+            .iter()
+            .all(|task| task.source != GOAL_PROGRESS_SUPERVISION_SOURCE),
+        "failing before the goal run is confirmed must not leave a queued supervisor behind"
+    );
 }
 
 #[tokio::test]

--- a/crates/zorai-daemon/src/agent/thread_participants.rs
+++ b/crates/zorai-daemon/src/agent/thread_participants.rs
@@ -748,7 +748,7 @@ impl AgentEngine {
         }
 
         let acquired_flush_slot = {
-            let mut active = self.active_visible_thread_continuation_flushes.lock().await;
+            let mut active = lock_flush_slots(&self.active_visible_thread_continuation_flushes);
             active.insert(thread_id.to_string())
         };
         if !acquired_flush_slot {
@@ -2210,13 +2210,21 @@ impl AgentEngine {
 }
 
 struct FlushSlotGuard<'a> {
-    slots: &'a Mutex<HashSet<String>>,
+    slots: &'a std::sync::Mutex<HashSet<String>>,
     thread_id: String,
     released: bool,
 }
 
+fn lock_flush_slots(
+    slots: &std::sync::Mutex<HashSet<String>>,
+) -> std::sync::MutexGuard<'_, HashSet<String>> {
+    slots
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 impl<'a> FlushSlotGuard<'a> {
-    fn new(slots: &'a Mutex<HashSet<String>>, thread_id: String) -> Self {
+    fn new(slots: &'a std::sync::Mutex<HashSet<String>>, thread_id: String) -> Self {
         Self {
             slots,
             thread_id,
@@ -2228,7 +2236,7 @@ impl<'a> FlushSlotGuard<'a> {
         if self.released {
             return;
         }
-        self.slots.lock().await.remove(&self.thread_id);
+        lock_flush_slots(self.slots).remove(&self.thread_id);
         self.released = true;
     }
 }
@@ -2238,10 +2246,8 @@ impl Drop for FlushSlotGuard<'_> {
         if self.released {
             return;
         }
-        if let Ok(mut active) = self.slots.try_lock() {
-            active.remove(&self.thread_id);
-            self.released = true;
-        }
+        lock_flush_slots(self.slots).remove(&self.thread_id);
+        self.released = true;
     }
 }
 
@@ -2330,19 +2336,30 @@ mod tests {
 
     #[tokio::test]
     async fn flush_slot_guard_does_not_steal_slot_acquired_after_release() {
-        let slots = Mutex::new(HashSet::new());
-        slots.lock().await.insert("thread-a".to_string());
+        let slots = std::sync::Mutex::new(HashSet::new());
+        lock_flush_slots(&slots).insert("thread-a".to_string());
         {
             let mut guard = FlushSlotGuard::new(&slots, "thread-a".to_string());
             guard.release().await;
             assert!(
-                slots.lock().await.insert("thread-a".to_string()),
+                lock_flush_slots(&slots).insert("thread-a".to_string()),
                 "after release another flush must be able to acquire the slot"
             );
         }
         assert!(
-            slots.lock().await.contains("thread-a"),
+            lock_flush_slots(&slots).contains("thread-a"),
             "drop after release must not steal the next flush's slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_slot_guard_drop_releases_slot_without_explicit_release() {
+        let slots = std::sync::Mutex::new(HashSet::new());
+        lock_flush_slots(&slots).insert("thread-a".to_string());
+        drop(FlushSlotGuard::new(&slots, "thread-a".to_string()));
+        assert!(
+            lock_flush_slots(&slots).insert("thread-a".to_string()),
+            "cancelling a flush before release() must still free the slot; try_lock on a tokio mutex leaves it stuck when the lock is busy"
         );
     }
 }

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -75,7 +75,7 @@ Minimal example:
 ```json
 {
   "name": "zorai-plugin-example",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "zoraiPlugin": {
     "entry": "dist/zorai-plugin.js",
     "format": "script"
@@ -102,7 +102,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.9.43",
+  version: "0.9.44",
   components: {
     ExamplePanel,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zorai",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zorai",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -158,8 +158,6 @@
         "deb"
       ],
       "icon": "assets/icon.png",
-      "afterInstall": "build/linux/after-install.sh",
-      "afterRemove": "build/linux/after-remove.sh",
       "extraResources": [
         {
           "from": "dist/zorai-daemon",
@@ -186,6 +184,10 @@
           "to": "bin/zorai-gateway"
         }
       ]
+    },
+    "deb": {
+      "afterInstall": "build/linux/after-install.sh",
+      "afterRemove": "build/linux/after-remove.sh"
     },
     "portable": {
       "artifactName": "zorai-portable.exe"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zorai",
   "private": true,
-  "version": "0.9.43",
+  "version": "0.9.44",
   "description": "Daemon-first agentic runtime with AI-native workflows",
   "homepage": "https://zorai.app",
   "author": {

--- a/frontend/scripts/linux-deb-sandbox.test.cjs
+++ b/frontend/scripts/linux-deb-sandbox.test.cjs
@@ -3,9 +3,13 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 
-const BUILD_LINUX_DIR = path.join(__dirname, "..", "build", "linux");
+const FRONTEND_DIR = path.join(__dirname, "..");
+const BUILD_LINUX_DIR = path.join(FRONTEND_DIR, "build", "linux");
 const AFTER_INSTALL = path.join(BUILD_LINUX_DIR, "after-install.sh");
 const AFTER_REMOVE = path.join(BUILD_LINUX_DIR, "after-remove.sh");
+const PACKAGE_CONFIG = JSON.parse(
+    fs.readFileSync(path.join(FRONTEND_DIR, "package.json"), "utf8"),
+);
 const ELECTRON_BUILDER_MACROS = new Set(["executable", "sanitizedProductName", "productFilename"]);
 const MACRO_PATTERN = /\$\{([a-zA-Z]+)\}/g;
 
@@ -33,6 +37,27 @@ function renderDebScripts() {
         afterRemove: interpolate(fs.readFileSync(AFTER_REMOVE, "utf8"), options),
     };
 }
+
+test("deb maintainer scripts are configured on deb, not linux", () => {
+    assert.equal(PACKAGE_CONFIG.build?.linux?.afterInstall, undefined);
+    assert.equal(PACKAGE_CONFIG.build?.linux?.afterRemove, undefined);
+    assert.equal(
+        PACKAGE_CONFIG.build?.deb?.afterInstall,
+        "build/linux/after-install.sh",
+    );
+    assert.equal(
+        PACKAGE_CONFIG.build?.deb?.afterRemove,
+        "build/linux/after-remove.sh",
+    );
+});
+
+test("electron-builder 25 schema accepts the current build field on every platform", () => {
+    const validateSchema = require("@develar/schema-utils");
+    const scheme = require("app-builder-lib/scheme.json");
+    validateSchema(scheme, PACKAGE_CONFIG.build, {
+        name: "electron-builder 25.1.8",
+    });
+});
 
 test("deb install scripts only use electron-builder linux macros", () => {
     for (const file of [AFTER_INSTALL, AFTER_REMOVE]) {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -58,7 +58,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>Zorai - Agent Orchestration Workspace</p>
-                    <p>Version 0.9.43</p>
+                    <p>Version 0.9.44</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A thread-first agent orchestration workspace with durable goals, workspace boards,
                         approvals, tools, and daemon-backed runtime state.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.9.43",
+        version: "0.9.44",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.9.43",
+        version: "0.9.44",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/zorai/features/settings/SettingsPanels.tsx
+++ b/frontend/src/zorai/features/settings/SettingsPanels.tsx
@@ -63,7 +63,7 @@ export const conciergeReasoningEffortOptions: Array<{ value: AgentSettings["reas
   { value: "xhigh", label: "xhigh" },
   { value: "max", label: "max" },
 ];
-const APP_VERSION = "0.9.43";
+const APP_VERSION = "0.9.44";
 const APP_AUTHOR = "Mariusz Kurman";
 const APP_GITHUB = "mkurman/zorai";
 const APP_HOMEPAGE = "zorai.app";

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zor-ai",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://zorai.app",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "zorai",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "zor-ai": "^0.9.42"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/zor-ai": {
+      "version": "0.9.42",
+      "resolved": "https://registry.npmjs.org/zor-ai/-/zor-ai-0.9.42.tgz",
+      "integrity": "sha512-CyrrkVxVxaRl5YeKNKWRDKQ16zsWRfnagOQNVFMEx2/PHPMfFgLu+1QSNqx9hUio4qDHg31ZC+rlgrs57U/YSQ==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "linux",
+        "darwin",
+        "win32"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16"
+      },
+      "bin": {
+        "zoi": "bin/zorai.js",
+        "zorai": "bin/zorai.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "zor-ai": "^0.9.42"
+  },
+  "allowScripts": {
+    "zor-ai@0.9.42": true
+  }
+}


### PR DESCRIPTION
Merge develop into main for v0.9.44.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon concurrency (flush-slot locking) and goal-planner task lifecycle, plus Linux packaging hooks. Incorrect mutex or cleanup behavior could stall threads or leave stray tasks; packaging misconfig would affect installers.
> 
> **Overview**
> Releases **v0.9.44** (workspace, frontend, plugins, npm package) and includes three targeted fixes.
> 
> **Thread continuation flushes** no longer use a tokio mutex whose `Drop` `try_lock` could leave a slot stuck. `active_visible_thread_continuation_flushes` is a `std::sync::Mutex`, with poison recovery, so cancelled flushes always release the slot.
> 
> **Progress supervision** confirms the goal run still exists before enqueueing. If it disappears after enqueue, the supervisor task is removed from memory and history instead of being left queued.
> 
> **Linux packaging** moves `afterInstall` / `afterRemove` from `build.linux` to `build.deb` so electron-builder 25 schema validation passes and AppImage is not given deb-only maintainer scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b80b01d41bd5c78b45e0c22a35ff62fffd521cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->