### PR TITLE
Release v0.9.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9690,7 +9690,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zorai-cli"
-version = "0.9.46"
+version = "0.9.47"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-daemon"
-version = "0.9.46"
+version = "0.9.47"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9782,7 +9782,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-gateway"
-version = "0.9.46"
+version = "0.9.47"
 dependencies = [
  "anyhow",
  "futures",
@@ -9801,7 +9801,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-mcp"
-version = "0.9.46"
+version = "0.9.47"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9820,7 +9820,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-protocol"
-version = "0.9.46"
+version = "0.9.47"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -9838,14 +9838,14 @@ dependencies = [
 
 [[package]]
 name = "zorai-shared"
-version = "0.9.46"
+version = "0.9.47"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "zorai-tui"
-version = "0.9.46"
+version = "0.9.47"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9690,7 +9690,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zorai-cli"
-version = "0.9.47"
+version = "0.9.48"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9714,7 +9714,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-daemon"
-version = "0.9.47"
+version = "0.9.48"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -9782,7 +9782,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-gateway"
-version = "0.9.47"
+version = "0.9.48"
 dependencies = [
  "anyhow",
  "futures",
@@ -9801,7 +9801,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-mcp"
-version = "0.9.47"
+version = "0.9.48"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9820,7 +9820,7 @@ dependencies = [
 
 [[package]]
 name = "zorai-protocol"
-version = "0.9.47"
+version = "0.9.48"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -9838,14 +9838,14 @@ dependencies = [
 
 [[package]]
 name = "zorai-shared"
-version = "0.9.47"
+version = "0.9.48"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "zorai-tui"
-version = "0.9.47"
+version = "0.9.48"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.46"
+version = "0.9.47"
 edition = "2021"
 license = "MIT"
 authors = ["zorai contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.47"
+version = "0.9.48"
 edition = "2021"
 license = "MIT"
 authors = ["zorai contributors"]

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/assembler.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/assembler.rs
@@ -1,3 +1,4 @@
+use super::assembler_support::*;
 use super::*;
 use crate::agent::types::AgentEvent;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -37,6 +38,8 @@ struct ActiveTurn {
     spans: Vec<CompletedTraceSpan>,
     llm: Option<ActiveSpan>,
     tools: HashMap<String, ActiveSpan>,
+    events: Vec<CompletedSpanEvent>,
+    dropped_events: u32,
     seen_terminal_message_ids: HashSet<String>,
     input_tokens: u64,
     output_tokens: u64,
@@ -77,6 +80,9 @@ impl TurnTraceAssembler {
             return;
         }
         let thread_id = thread_id.to_string();
+        if !opens_turn(&event) && !self.active.contains_key(&thread_id) {
+            return;
+        }
         let context_input_tokens = context.input_tokens;
         let context_output_tokens = context.output_tokens;
         let context_cache_read = context.cache_read_input_tokens;
@@ -207,6 +213,46 @@ impl TurnTraceAssembler {
                     None,
                 );
             }
+            AgentEvent::ApprovalRequired {
+                approval_id,
+                command,
+                risk_level,
+                ..
+            } => {
+                record_span_event(
+                    &mut turn.events,
+                    &mut turn.dropped_events,
+                    at_ms,
+                    "approval_required",
+                    approval_event_attributes(&approval_id, &command, &risk_level),
+                    self.config.max_events_per_span,
+                );
+            }
+            AgentEvent::RetryStatus {
+                phase,
+                attempt,
+                max_retries,
+                delay_ms,
+                failure_class,
+                message,
+                ..
+            } => {
+                record_span_event(
+                    &mut turn.events,
+                    &mut turn.dropped_events,
+                    at_ms,
+                    "retry_status",
+                    retry_event_attributes(
+                        &phase,
+                        attempt,
+                        max_retries,
+                        delay_ms,
+                        &failure_class,
+                        &message,
+                    ),
+                    self.config.max_events_per_span,
+                );
+            }
             _ => {}
         }
     }
@@ -314,6 +360,8 @@ impl TurnTraceAssembler {
                 spans: Vec::new(),
                 llm: None,
                 tools: HashMap::new(),
+                events: Vec::new(),
+                dropped_events: 0,
                 seen_terminal_message_ids: HashSet::new(),
                 input_tokens,
                 output_tokens,
@@ -371,7 +419,7 @@ impl TurnTraceAssembler {
             .context
             .relationships
             .classify_scope(turn.context.autonomous);
-        let trace = CompletedTurnTrace {
+        let mut trace = CompletedTurnTrace {
             trace_id: turn.trace_id,
             root_span_id: turn.root_span_id,
             relationships: turn.context.relationships,
@@ -386,6 +434,8 @@ impl TurnTraceAssembler {
             output,
             reasoning,
             spans: turn.spans,
+            events: turn.events,
+            dropped_events: turn.dropped_events,
             input_tokens,
             output_tokens,
             cache_read_input_tokens,
@@ -394,6 +444,7 @@ impl TurnTraceAssembler {
             provider,
             model,
         };
+        cap_completed_trace(&mut trace, self.config.max_trace_bytes);
         while self.completed.len() >= self.config.queue_capacity {
             self.completed.pop_front();
         }
@@ -436,49 +487,4 @@ fn finish_span(turn: &mut ActiveTurn, span: ActiveSpan, at_ms: u64, outcome: Mlf
         output: span.output,
         call_id: span.call_id,
     });
-}
-
-fn append_capped(target: &mut String, value: &str, max_chars: usize) {
-    let remaining = max_chars.saturating_sub(target.chars().count());
-    target.extend(value.chars().take(remaining));
-}
-
-fn random_trace_id() -> [u8; 16] {
-    *uuid::Uuid::new_v4().as_bytes()
-}
-
-fn random_span_id() -> [u8; 8] {
-    let bytes = uuid::Uuid::new_v4();
-    let mut id = [0; 8];
-    id.copy_from_slice(&bytes.as_bytes()[..8]);
-    id
-}
-
-fn is_traceable(event: &AgentEvent) -> bool {
-    matches!(
-        event,
-        AgentEvent::Delta { .. }
-            | AgentEvent::Reasoning { .. }
-            | AgentEvent::ToolCall { .. }
-            | AgentEvent::ToolResult { .. }
-            | AgentEvent::Done { .. }
-            | AgentEvent::Error { .. }
-            | AgentEvent::ApprovalRequired { .. }
-            | AgentEvent::RetryStatus { .. }
-    )
-}
-
-fn event_thread_id(event: &AgentEvent) -> Option<&str> {
-    match event {
-        AgentEvent::Delta { thread_id, .. }
-        | AgentEvent::Reasoning { thread_id, .. }
-        | AgentEvent::ToolCall { thread_id, .. }
-        | AgentEvent::ToolResult { thread_id, .. }
-        | AgentEvent::Done { thread_id, .. }
-        | AgentEvent::Error { thread_id, .. }
-        | AgentEvent::TurnInterrupted { thread_id }
-        | AgentEvent::ApprovalRequired { thread_id, .. }
-        | AgentEvent::RetryStatus { thread_id, .. } => Some(thread_id),
-        _ => None,
-    }
 }

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/assembler_support.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/assembler_support.rs
@@ -1,0 +1,107 @@
+use super::CompletedSpanEvent;
+use crate::agent::types::AgentEvent;
+
+pub(super) fn opens_turn(event: &AgentEvent) -> bool {
+    matches!(
+        event,
+        AgentEvent::Delta { .. } | AgentEvent::Reasoning { .. } | AgentEvent::ToolCall { .. }
+    )
+}
+
+pub(super) fn is_traceable(event: &AgentEvent) -> bool {
+    matches!(
+        event,
+        AgentEvent::Delta { .. }
+            | AgentEvent::Reasoning { .. }
+            | AgentEvent::ToolCall { .. }
+            | AgentEvent::ToolResult { .. }
+            | AgentEvent::Done { .. }
+            | AgentEvent::Error { .. }
+            | AgentEvent::ApprovalRequired { .. }
+            | AgentEvent::RetryStatus { .. }
+    )
+}
+
+pub(super) fn event_thread_id(event: &AgentEvent) -> Option<&str> {
+    match event {
+        AgentEvent::Delta { thread_id, .. }
+        | AgentEvent::Reasoning { thread_id, .. }
+        | AgentEvent::ToolCall { thread_id, .. }
+        | AgentEvent::ToolResult { thread_id, .. }
+        | AgentEvent::Done { thread_id, .. }
+        | AgentEvent::Error { thread_id, .. }
+        | AgentEvent::TurnInterrupted { thread_id }
+        | AgentEvent::ApprovalRequired { thread_id, .. }
+        | AgentEvent::RetryStatus { thread_id, .. } => Some(thread_id),
+        _ => None,
+    }
+}
+
+pub(super) fn record_span_event(
+    events: &mut Vec<CompletedSpanEvent>,
+    dropped_events: &mut u32,
+    at_ms: u64,
+    name: &str,
+    attributes: Vec<(String, String)>,
+    max_events: usize,
+) {
+    if events.len() >= max_events {
+        *dropped_events = dropped_events.saturating_add(1);
+        return;
+    }
+    events.push(CompletedSpanEvent {
+        name: name.into(),
+        at_ms,
+        attributes,
+    });
+}
+
+pub(super) fn append_capped(target: &mut String, value: &str, max_chars: usize) {
+    let remaining = max_chars.saturating_sub(target.chars().count());
+    target.extend(value.chars().take(remaining));
+}
+
+pub(super) fn random_trace_id() -> [u8; 16] {
+    *uuid::Uuid::new_v4().as_bytes()
+}
+
+pub(super) fn random_span_id() -> [u8; 8] {
+    let bytes = uuid::Uuid::new_v4();
+    let mut id = [0; 8];
+    id.copy_from_slice(&bytes.as_bytes()[..8]);
+    id
+}
+
+fn attr_text(value: &str) -> String {
+    value.chars().take(256).collect()
+}
+
+pub(super) fn approval_event_attributes(
+    approval_id: &str,
+    command: &str,
+    risk_level: &str,
+) -> Vec<(String, String)> {
+    vec![
+        ("approval_id".into(), attr_text(approval_id)),
+        ("risk_level".into(), attr_text(risk_level)),
+        ("command".into(), attr_text(command)),
+    ]
+}
+
+pub(super) fn retry_event_attributes(
+    phase: &str,
+    attempt: u32,
+    max_retries: u32,
+    delay_ms: u64,
+    failure_class: &str,
+    message: &str,
+) -> Vec<(String, String)> {
+    vec![
+        ("phase".into(), attr_text(phase)),
+        ("attempt".into(), attempt.to_string()),
+        ("max_retries".into(), max_retries.to_string()),
+        ("delay_ms".into(), delay_ms.to_string()),
+        ("failure_class".into(), attr_text(failure_class)),
+        ("message".into(), attr_text(message)),
+    ]
+}

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/bounds.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/bounds.rs
@@ -1,0 +1,155 @@
+use super::{encode_otlp_batch, CapturedValue, CompletedTurnTrace};
+
+pub fn cap_completed_trace(trace: &mut CompletedTurnTrace, max_bytes: usize) {
+    for _ in 0..48 {
+        let encoded = match encode_otlp_batch(std::slice::from_ref(trace)) {
+            Ok(bytes) => bytes,
+            Err(_) => return,
+        };
+        if encoded.len() <= max_bytes {
+            return;
+        }
+        if !shrink_trace_payloads(trace) {
+            mark_trace_bytes(trace);
+            return;
+        }
+        mark_trace_bytes(trace);
+    }
+}
+
+fn mark_trace_bytes(trace: &mut CompletedTurnTrace) {
+    if trace.partial_reason.is_none() {
+        trace.partial_reason = Some("trace_bytes".into());
+    }
+}
+
+fn shrink_trace_payloads(trace: &mut CompletedTurnTrace) -> bool {
+    let mut best = ShrinkTarget::None;
+    let mut best_len = 0usize;
+    consider_captured(&mut best, &mut best_len, ShrinkTarget::Input, &trace.input);
+    consider_captured(
+        &mut best,
+        &mut best_len,
+        ShrinkTarget::Output,
+        &trace.output,
+    );
+    consider_captured(
+        &mut best,
+        &mut best_len,
+        ShrinkTarget::Reasoning,
+        &trace.reasoning,
+    );
+    for (index, span) in trace.spans.iter().enumerate() {
+        consider_captured(
+            &mut best,
+            &mut best_len,
+            ShrinkTarget::SpanInput(index),
+            &span.input,
+        );
+        consider_captured(
+            &mut best,
+            &mut best_len,
+            ShrinkTarget::SpanOutput(index),
+            &span.output,
+        );
+    }
+    for (event_index, event) in trace.events.iter().enumerate() {
+        for (attr_index, (_, value)) in event.attributes.iter().enumerate() {
+            if value.len() > best_len {
+                best_len = value.len();
+                best = ShrinkTarget::EventAttr {
+                    event: event_index,
+                    attr: attr_index,
+                };
+            }
+        }
+    }
+    if best_len > 0 {
+        return apply_shrink(trace, best);
+    }
+    if trace.events.pop().is_some() {
+        trace.dropped_events = trace.dropped_events.saturating_add(1);
+        return true;
+    }
+    if trace.spans.pop().is_some() {
+        if trace.partial_reason.is_none() {
+            trace.partial_reason = Some("trace_bytes".into());
+        }
+        return true;
+    }
+    false
+}
+
+#[derive(Clone, Copy)]
+enum ShrinkTarget {
+    None,
+    Input,
+    Output,
+    Reasoning,
+    SpanInput(usize),
+    SpanOutput(usize),
+    EventAttr { event: usize, attr: usize },
+}
+
+fn consider_captured(
+    best: &mut ShrinkTarget,
+    best_len: &mut usize,
+    target: ShrinkTarget,
+    value: &Option<CapturedValue>,
+) {
+    let Some(captured) = value else {
+        return;
+    };
+    if captured.value.len() > *best_len {
+        *best_len = captured.value.len();
+        *best = target;
+    }
+}
+
+fn apply_shrink(trace: &mut CompletedTurnTrace, target: ShrinkTarget) -> bool {
+    match target {
+        ShrinkTarget::None => false,
+        ShrinkTarget::Input => shrink_captured(&mut trace.input),
+        ShrinkTarget::Output => shrink_captured(&mut trace.output),
+        ShrinkTarget::Reasoning => shrink_captured(&mut trace.reasoning),
+        ShrinkTarget::SpanInput(index) => trace
+            .spans
+            .get_mut(index)
+            .is_some_and(|span| shrink_captured(&mut span.input)),
+        ShrinkTarget::SpanOutput(index) => trace
+            .spans
+            .get_mut(index)
+            .is_some_and(|span| shrink_captured(&mut span.output)),
+        ShrinkTarget::EventAttr { event, attr } => {
+            let Some(value) = trace
+                .events
+                .get_mut(event)
+                .and_then(|entry| entry.attributes.get_mut(attr))
+                .map(|(_, value)| value)
+            else {
+                return false;
+            };
+            shrink_string(value)
+        }
+    }
+}
+
+fn shrink_captured(value: &mut Option<CapturedValue>) -> bool {
+    let Some(captured) = value.as_mut() else {
+        return false;
+    };
+    if !shrink_string(&mut captured.value) {
+        return false;
+    }
+    captured.truncated = true;
+    true
+}
+
+fn shrink_string(value: &mut String) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    let keep = value.chars().count() / 2;
+    *value = value.chars().take(keep).collect();
+    true
+}

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/bounds.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/bounds.rs
@@ -1,19 +1,28 @@
 use super::{encode_otlp_batch, CapturedValue, CompletedTurnTrace};
 
 pub fn cap_completed_trace(trace: &mut CompletedTurnTrace, max_bytes: usize) {
-    for _ in 0..48 {
-        let encoded = match encode_otlp_batch(std::slice::from_ref(trace)) {
-            Ok(bytes) => bytes,
+    loop {
+        match encode_otlp_batch(std::slice::from_ref(trace)) {
+            Ok(bytes) if bytes.len() <= max_bytes => return,
             Err(_) => return,
-        };
-        if encoded.len() <= max_bytes {
-            return;
-        }
-        if !shrink_trace_payloads(trace) {
-            mark_trace_bytes(trace);
-            return;
+            Ok(_) => {}
         }
         mark_trace_bytes(trace);
+        if shrink_all_captured(trace) {
+            continue;
+        }
+        if !trace.events.is_empty() {
+            trace.dropped_events = trace
+                .dropped_events
+                .saturating_add(trace.events.len() as u32);
+            trace.events.clear();
+            continue;
+        }
+        if trace.spans.is_empty() {
+            return;
+        }
+        let keep = trace.spans.len() / 2;
+        trace.spans.truncate(keep);
     }
 }
 
@@ -23,115 +32,21 @@ fn mark_trace_bytes(trace: &mut CompletedTurnTrace) {
     }
 }
 
-fn shrink_trace_payloads(trace: &mut CompletedTurnTrace) -> bool {
-    let mut best = ShrinkTarget::None;
-    let mut best_len = 0usize;
-    consider_captured(&mut best, &mut best_len, ShrinkTarget::Input, &trace.input);
-    consider_captured(
-        &mut best,
-        &mut best_len,
-        ShrinkTarget::Output,
-        &trace.output,
-    );
-    consider_captured(
-        &mut best,
-        &mut best_len,
-        ShrinkTarget::Reasoning,
-        &trace.reasoning,
-    );
-    for (index, span) in trace.spans.iter().enumerate() {
-        consider_captured(
-            &mut best,
-            &mut best_len,
-            ShrinkTarget::SpanInput(index),
-            &span.input,
-        );
-        consider_captured(
-            &mut best,
-            &mut best_len,
-            ShrinkTarget::SpanOutput(index),
-            &span.output,
-        );
+fn shrink_all_captured(trace: &mut CompletedTurnTrace) -> bool {
+    let mut changed = false;
+    changed |= shrink_captured(&mut trace.input);
+    changed |= shrink_captured(&mut trace.output);
+    changed |= shrink_captured(&mut trace.reasoning);
+    for span in &mut trace.spans {
+        changed |= shrink_captured(&mut span.input);
+        changed |= shrink_captured(&mut span.output);
     }
-    for (event_index, event) in trace.events.iter().enumerate() {
-        for (attr_index, (_, value)) in event.attributes.iter().enumerate() {
-            if value.len() > best_len {
-                best_len = value.len();
-                best = ShrinkTarget::EventAttr {
-                    event: event_index,
-                    attr: attr_index,
-                };
-            }
+    for event in &mut trace.events {
+        for (_, value) in &mut event.attributes {
+            changed |= shrink_string(value);
         }
     }
-    if best_len > 0 {
-        return apply_shrink(trace, best);
-    }
-    if trace.events.pop().is_some() {
-        trace.dropped_events = trace.dropped_events.saturating_add(1);
-        return true;
-    }
-    if trace.spans.pop().is_some() {
-        if trace.partial_reason.is_none() {
-            trace.partial_reason = Some("trace_bytes".into());
-        }
-        return true;
-    }
-    false
-}
-
-#[derive(Clone, Copy)]
-enum ShrinkTarget {
-    None,
-    Input,
-    Output,
-    Reasoning,
-    SpanInput(usize),
-    SpanOutput(usize),
-    EventAttr { event: usize, attr: usize },
-}
-
-fn consider_captured(
-    best: &mut ShrinkTarget,
-    best_len: &mut usize,
-    target: ShrinkTarget,
-    value: &Option<CapturedValue>,
-) {
-    let Some(captured) = value else {
-        return;
-    };
-    if captured.value.len() > *best_len {
-        *best_len = captured.value.len();
-        *best = target;
-    }
-}
-
-fn apply_shrink(trace: &mut CompletedTurnTrace, target: ShrinkTarget) -> bool {
-    match target {
-        ShrinkTarget::None => false,
-        ShrinkTarget::Input => shrink_captured(&mut trace.input),
-        ShrinkTarget::Output => shrink_captured(&mut trace.output),
-        ShrinkTarget::Reasoning => shrink_captured(&mut trace.reasoning),
-        ShrinkTarget::SpanInput(index) => trace
-            .spans
-            .get_mut(index)
-            .is_some_and(|span| shrink_captured(&mut span.input)),
-        ShrinkTarget::SpanOutput(index) => trace
-            .spans
-            .get_mut(index)
-            .is_some_and(|span| shrink_captured(&mut span.output)),
-        ShrinkTarget::EventAttr { event, attr } => {
-            let Some(value) = trace
-                .events
-                .get_mut(event)
-                .and_then(|entry| entry.attributes.get_mut(attr))
-                .map(|(_, value)| value)
-            else {
-                return false;
-            };
-            shrink_string(value)
-        }
-    }
+    changed
 }
 
 fn shrink_captured(value: &mut Option<CapturedValue>) -> bool {

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/mod.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/mod.rs
@@ -1,4 +1,6 @@
 mod assembler;
+mod assembler_support;
+mod bounds;
 mod config;
 mod enrichment;
 mod mlflow_client;
@@ -12,6 +14,7 @@ mod types;
 mod worker;
 
 pub(crate) use assembler::*;
+pub(crate) use bounds::*;
 pub(crate) use config::*;
 pub(crate) use enrichment::*;
 pub(crate) use mlflow_client::*;

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/otlp.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/otlp.rs
@@ -286,8 +286,8 @@ fn root_span(trace: &CompletedTurnTrace) -> OtlpSpan {
         end_time_unix_nano: millis_to_nanos(trace.ended_at_ms),
         attributes,
         dropped_attributes_count: 0,
-        events: Vec::new(),
-        dropped_events_count: 0,
+        events: encode_events(&trace.events),
+        dropped_events_count: trace.dropped_events,
         links: Vec::new(),
         dropped_links_count: 0,
         status: Some(status(trace.outcome, trace.partial_reason.as_deref())),
@@ -365,6 +365,8 @@ fn relationship_attributes(trace: &CompletedTurnTrace) -> Vec<KeyValue> {
     let relationships = &trace.relationships;
     let mut values = vec![
         kv_string("zorai.thread.id", &relationships.thread_id),
+        kv_string("session.id", &relationships.thread_id),
+        kv_string("gen_ai.conversation.id", &relationships.thread_id),
         kv_i64("zorai.turn.generation", trace.generation as i64),
     ];
     for (key, value) in [
@@ -407,17 +409,43 @@ fn relationship_attributes(trace: &CompletedTurnTrace) -> Vec<KeyValue> {
 }
 
 fn capture_flags(trace: &CompletedTurnTrace) -> (&'static str, &'static str) {
-    let values = [
+    let mut values: Vec<&CapturedValue> = [
         trace.input.as_ref(),
         trace.output.as_ref(),
         trace.reasoning.as_ref(),
-    ];
-    let redacted = values.iter().flatten().any(|value| value.redacted);
-    let truncated = values.iter().flatten().any(|value| value.truncated);
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    for span in &trace.spans {
+        values.extend(
+            [span.input.as_ref(), span.output.as_ref()]
+                .into_iter()
+                .flatten(),
+        );
+    }
+    let redacted = values.iter().any(|value| value.redacted);
+    let truncated = values.iter().any(|value| value.truncated);
     (
         if redacted { "true" } else { "false" },
         if truncated { "true" } else { "false" },
     )
+}
+
+fn encode_events(events: &[CompletedSpanEvent]) -> Vec<SpanEvent> {
+    events
+        .iter()
+        .map(|event| SpanEvent {
+            time_unix_nano: millis_to_nanos(event.at_ms),
+            name: event.name.clone(),
+            attributes: event
+                .attributes
+                .iter()
+                .map(|(key, value)| kv_string(key, value))
+                .collect(),
+            dropped_attributes_count: 0,
+        })
+        .collect()
 }
 
 fn message_json(role: &str, content: &str) -> String {

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/tests/assembler.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/tests/assembler.rs
@@ -349,3 +349,159 @@ fn interrupt_then_follow_up_starts_a_new_turn() {
     assert_eq!(trace.input.as_ref().unwrap().value, "follow up");
     assert_eq!(trace.output.as_ref().unwrap().value, "A2");
 }
+
+fn error_event(thread: &str, message: &str) -> AgentEvent {
+    AgentEvent::Error {
+        thread_id: thread.into(),
+        message: message.into(),
+    }
+}
+
+fn retry_event(thread: &str, attempt: u32) -> AgentEvent {
+    AgentEvent::RetryStatus {
+        thread_id: thread.into(),
+        phase: "provider".into(),
+        attempt,
+        max_retries: 3,
+        delay_ms: 25,
+        failure_class: "timeout".into(),
+        message: "retry".into(),
+    }
+}
+
+fn approval_event(thread: &str) -> AgentEvent {
+    AgentEvent::ApprovalRequired {
+        thread_id: thread.into(),
+        approval_id: "ap1".into(),
+        command: "ls".into(),
+        rationale: None,
+        reasons: Vec::new(),
+        risk_level: "low".into(),
+        blast_radius: "low".into(),
+    }
+}
+
+#[test]
+fn error_then_done_does_not_open_a_second_trace() {
+    let mut assembler = TurnTraceAssembler::new(MlflowTracingConfig::default());
+    assembler.observe(
+        1_000,
+        AgentEvent::Delta {
+            thread_id: "t1".into(),
+            content: "Hello".into(),
+        },
+        context("t1"),
+    );
+    assembler.observe(
+        1_050,
+        error_event("t1", "Tool execution limit reached"),
+        context("t1"),
+    );
+    assembler.observe(1_060, done("t1", "a1"), context("t1"));
+    let traces = assembler.drain_completed();
+    assert_eq!(
+        traces.len(),
+        1,
+        "deferred Done after Error must not finish a second empty turn that would steal the next FIFO anchor"
+    );
+    assert_eq!(traces[0].outcome, MlflowTraceOutcome::Error);
+    assert_eq!(assembler.active_len(), 0);
+}
+
+#[test]
+fn late_retry_and_approval_do_not_open_empty_turns() {
+    let mut assembler = TurnTraceAssembler::new(MlflowTracingConfig::default());
+    assembler.observe(
+        1_000,
+        AgentEvent::Delta {
+            thread_id: "t1".into(),
+            content: "Hello".into(),
+        },
+        context("t1"),
+    );
+    assembler.observe(1_100, done("t1", "a1"), context("t1"));
+    assembler.drain_completed();
+    assembler.observe(1_200, retry_event("t1", 1), context("t1"));
+    assembler.observe(1_250, approval_event("t1"), context("t1"));
+    assert_eq!(assembler.active_len(), 0);
+    assert!(
+        assembler.drain_completed().is_empty(),
+        "late approval/retry after the real turn finished must not export a stale empty trace"
+    );
+}
+
+#[test]
+fn retry_and_approval_during_a_live_turn_are_recorded_as_events() {
+    let mut assembler = TurnTraceAssembler::new(MlflowTracingConfig::default());
+    assembler.observe(
+        1_000,
+        AgentEvent::Delta {
+            thread_id: "t1".into(),
+            content: "Hello".into(),
+        },
+        context("t1"),
+    );
+    assembler.observe(1_020, retry_event("t1", 1), context("t1"));
+    assembler.observe(1_040, approval_event("t1"), context("t1"));
+    assembler.observe(1_100, done("t1", "a1"), context("t1"));
+    let trace = assembler.drain_completed().pop().unwrap();
+    assert_eq!(
+        trace
+            .events
+            .iter()
+            .map(|event| event.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["retry_status", "approval_required"]
+    );
+    assert_eq!(trace.dropped_events, 0);
+}
+
+#[test]
+fn max_events_per_span_drops_extra_retry_events() {
+    let mut config = MlflowTracingConfig::default();
+    config.max_events_per_span = 2;
+    let mut assembler = TurnTraceAssembler::new(config);
+    assembler.observe(
+        1_000,
+        AgentEvent::Delta {
+            thread_id: "t1".into(),
+            content: "Hello".into(),
+        },
+        context("t1"),
+    );
+    assembler.observe(1_010, retry_event("t1", 1), context("t1"));
+    assembler.observe(1_020, retry_event("t1", 2), context("t1"));
+    assembler.observe(1_030, retry_event("t1", 3), context("t1"));
+    assembler.observe(1_100, done("t1", "a1"), context("t1"));
+    let trace = assembler.drain_completed().pop().unwrap();
+    assert_eq!(trace.events.len(), 2);
+    assert_eq!(trace.dropped_events, 1);
+}
+
+#[test]
+fn max_trace_bytes_shrinks_exported_payloads() {
+    let mut config = MlflowTracingConfig::default();
+    config.max_trace_bytes = 16 * 1024;
+    let mut assembler = TurnTraceAssembler::new(config);
+    assembler.observe(
+        1_000,
+        AgentEvent::Delta {
+            thread_id: "t1".into(),
+            content: "assistant reply with spaces. ".repeat(2_000),
+        },
+        context("t1"),
+    );
+    assembler.observe(1_100, done("t1", "a1"), context("t1"));
+    let trace = assembler.drain_completed().pop().unwrap();
+    let encoded = encode_otlp_batch(std::slice::from_ref(&trace)).unwrap();
+    assert!(
+        encoded.len() <= 16 * 1024,
+        "encoded OTLP must honor max_trace_bytes, got {}",
+        encoded.len()
+    );
+    assert_eq!(trace.partial_reason.as_deref(), Some("trace_bytes"));
+    assert!(
+        trace.output.as_ref().is_some_and(|output| output.truncated),
+        "byte-budget enforcement must mark captured output as truncated"
+    );
+}

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/tests/otlp.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/tests/otlp.rs
@@ -292,3 +292,48 @@ fn cap_completed_trace_keeps_encoded_batch_under_max_trace_bytes() {
     assert_eq!(trace.partial_reason.as_deref(), Some("trace_bytes"));
     assert!(trace.output.as_ref().unwrap().truncated);
 }
+
+#[test]
+fn cap_completed_trace_enforces_budget_for_many_tool_payloads() {
+    let mut trace = fixture_trace();
+    let payload = "tool result with spaces. ".repeat(80);
+    trace.spans = (0..80)
+        .map(|index| CompletedTraceSpan {
+            span_id: [index as u8; 8],
+            parent_span_id: [2; 8],
+            name: format!("zorai.tool t{index}"),
+            kind: MlflowSpanKind::Tool,
+            started_at_ms: 1_400,
+            ended_at_ms: 1_600,
+            timing_inferred: false,
+            outcome: MlflowTraceOutcome::Ok,
+            input: Some(CapturedValue {
+                value: payload.clone(),
+                redacted: false,
+                truncated: false,
+                original_chars: payload.chars().count(),
+            }),
+            output: Some(CapturedValue {
+                value: payload.clone(),
+                redacted: false,
+                truncated: false,
+                original_chars: payload.chars().count(),
+            }),
+            call_id: Some(format!("c{index}")),
+        })
+        .collect();
+    let uncapped = encode_otlp_batch(std::slice::from_ref(&trace)).unwrap();
+    assert!(
+        uncapped.len() > 16 * 1024,
+        "tool-heavy fixture must start over the budget, got {}",
+        uncapped.len()
+    );
+    cap_completed_trace(&mut trace, 16 * 1024);
+    let encoded = encode_otlp_batch(std::slice::from_ref(&trace)).unwrap();
+    assert!(
+        encoded.len() <= 16 * 1024,
+        "48 single-payload halvings are not enough for 80 tool spans; encoded {}",
+        encoded.len()
+    );
+    assert_eq!(trace.partial_reason.as_deref(), Some("trace_bytes"));
+}

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/tests/otlp.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/tests/otlp.rs
@@ -71,6 +71,8 @@ fn fixture_trace() -> CompletedTurnTrace {
                 call_id: Some("c1".into()),
             },
         ],
+        events: Vec::new(),
+        dropped_events: 0,
         input_tokens: 10,
         output_tokens: 4,
         cache_read_input_tokens: 0,
@@ -117,6 +119,16 @@ fn otlp_batch_preserves_hierarchy_and_mlflow_genai_attributes() {
         string_attr(root, "gen_ai.operation.name"),
         Some("invoke_agent")
     );
+    assert_eq!(
+        string_attr(root, "session.id"),
+        Some("thread-1"),
+        "MLflow maps session.id to mlflow.trace.session so Group by session can join turns in one thread"
+    );
+    assert_eq!(
+        string_attr(root, "gen_ai.conversation.id"),
+        Some("thread-1")
+    );
+    assert_eq!(string_attr(root, "zorai.thread.id"), Some("thread-1"));
     assert_eq!(string_attr(root, "gen_ai.provider.name"), Some("openai"));
     assert_eq!(string_attr(root, "gen_ai.response.model"), Some("gpt-test"));
     assert!(string_attr(root, "gen_ai.input.messages")
@@ -221,4 +233,62 @@ fn otlp_batch_uses_standard_resource_identity() {
     assert!(attributes
         .iter()
         .any(|entry| entry.key == "service.version"));
+}
+
+#[test]
+fn otlp_root_span_exports_recorded_events_and_dropped_count() {
+    let mut trace = fixture_trace();
+    trace.events = vec![CompletedSpanEvent {
+        name: "retry_status".into(),
+        at_ms: 1_500,
+        attributes: vec![("attempt".into(), "1".into())],
+    }];
+    trace.dropped_events = 2;
+    let request =
+        ExportTraceServiceRequest::decode(encode_otlp_batch(&[trace]).unwrap().as_slice()).unwrap();
+    let root = request.resource_spans[0].scope_spans[0]
+        .spans
+        .iter()
+        .find(|span| span.parent_span_id.is_empty())
+        .unwrap();
+    assert_eq!(root.events.len(), 1);
+    assert_eq!(root.events[0].name, "retry_status");
+    assert_eq!(root.dropped_events_count, 2);
+    assert_eq!(
+        root.events[0]
+            .attributes
+            .iter()
+            .find(|entry| entry.key == "attempt")
+            .and_then(|entry| match entry.value.as_ref()?.value.as_ref()? {
+                any_value::Value::StringValue(value) => Some(value.as_str()),
+                _ => None,
+            }),
+        Some("1")
+    );
+}
+
+#[test]
+fn cap_completed_trace_keeps_encoded_batch_under_max_trace_bytes() {
+    let mut trace = fixture_trace();
+    trace.output = Some(CapturedValue {
+        value: "assistant reply with spaces. ".repeat(2_000),
+        redacted: false,
+        truncated: false,
+        original_chars: 58_000,
+    });
+    let uncapped = encode_otlp_batch(std::slice::from_ref(&trace)).unwrap();
+    assert!(
+        uncapped.len() > 16 * 1024,
+        "fixture must start over the budget, got {}",
+        uncapped.len()
+    );
+    cap_completed_trace(&mut trace, 16 * 1024);
+    let encoded = encode_otlp_batch(std::slice::from_ref(&trace)).unwrap();
+    assert!(
+        encoded.len() <= 16 * 1024,
+        "encoded OTLP must honor max_trace_bytes, got {}",
+        encoded.len()
+    );
+    assert_eq!(trace.partial_reason.as_deref(), Some("trace_bytes"));
+    assert!(trace.output.as_ref().unwrap().truncated);
 }

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/tests/turn_anchors.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/tests/turn_anchors.rs
@@ -263,3 +263,64 @@ fn disable_reconfigure_finishes_in_flight_turn_and_releases_only_its_anchor() {
         "only the interrupted turn's prompt is consumed"
     );
 }
+
+#[test]
+fn pre_stream_error_releases_the_queued_prompt_so_the_next_turn_keeps_its_input() {
+    let (_dir, runtime) = runtime();
+    let mut assembler = TurnTraceAssembler::new(MlflowTracingConfig::default());
+    push(&runtime, "t1", "first", 1);
+    push(&runtime, "t1", "second", 2);
+
+    assembler.observe(
+        1_000,
+        AgentEvent::Error {
+            thread_id: "t1".into(),
+            message: "Provider unavailable".into(),
+        },
+        observation_context("t1"),
+    );
+    let completed = assembler.drain_completed().len();
+    release_anchor_for_untraced_error(&runtime, &assembler, "t1", completed);
+
+    assert_eq!(
+        completed, 0,
+        "Error without Delta/Reasoning/ToolCall must not open a turn"
+    );
+    assert_eq!(
+        runtime.front_turn_anchor("t1").unwrap().content,
+        "second",
+        "a provider failure before the first stream token must consume its own FIFO prompt"
+    );
+}
+
+#[test]
+fn error_that_finished_a_live_turn_does_not_extra_pop_the_next_prompt() {
+    let (_dir, runtime) = runtime();
+    let mut assembler = TurnTraceAssembler::new(MlflowTracingConfig::default());
+    push(&runtime, "t1", "first", 1);
+    push(&runtime, "t1", "second", 2);
+    assembler.observe(1_000, delta("t1"), observation_context("t1"));
+    assembler.observe(
+        1_050,
+        AgentEvent::Error {
+            thread_id: "t1".into(),
+            message: "Tool execution limit reached".into(),
+        },
+        observation_context("t1"),
+    );
+    let traces = assembler.drain_completed();
+    let completed = traces.len();
+    for trace in traces {
+        runtime.pop_turn_anchor(&trace.relationships.thread_id);
+    }
+    release_anchor_for_untraced_error(&runtime, &assembler, "t1", completed);
+    assembler.observe(1_060, done("t1"), observation_context("t1"));
+    assert_eq!(assembler.drain_completed().len(), 0);
+
+    assert_eq!(completed, 1);
+    assert_eq!(
+        runtime.front_turn_anchor("t1").unwrap().content,
+        "second",
+        "deferred Done after a traced Error must not steal the next queued prompt"
+    );
+}

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/tests/turn_anchors.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/tests/turn_anchors.rs
@@ -175,6 +175,32 @@ fn select_turn_user_follows_released_queue_front() {
 }
 
 #[test]
+fn retry_of_the_same_user_message_does_not_leave_a_duplicate_anchor() {
+    let (_dir, runtime) = runtime();
+    push(&runtime, "t1", "first", 1);
+    push(&runtime, "t1", "first", 1);
+    push(&runtime, "t1", "second", 2);
+
+    assert_eq!(runtime.pop_turn_anchor("t1").unwrap().content, "first");
+    assert_eq!(
+        runtime.pop_turn_anchor("t1").unwrap().content,
+        "second",
+        "a fresh_runner_retry re-init must not keep an extra copy of the first prompt in front of the next turn"
+    );
+    assert!(runtime.front_turn_anchor("t1").is_none());
+}
+
+#[test]
+fn completed_turn_can_requeue_the_same_user_message_id_on_a_later_resend() {
+    let (_dir, runtime) = runtime();
+    push(&runtime, "t1", "first", 1);
+    runtime.pop_turn_anchor("t1");
+    push(&runtime, "t1", "first", 2);
+
+    assert_eq!(runtime.front_turn_anchor("t1").unwrap().content, "first");
+}
+
+#[test]
 fn unrelated_reconfigure_keeps_in_flight_turn_and_its_queued_prompt() {
     let (_dir, runtime) = runtime();
     let mut assembler = TurnTraceAssembler::new(MlflowTracingConfig::default());

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/turn_anchors.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/turn_anchors.rs
@@ -17,6 +17,12 @@ impl MlflowTracingRuntime {
             .lock()
             .expect("MLflow turn anchor mutex poisoned");
         let queue = anchors.entry(thread_id.to_string()).or_default();
+        if queue
+            .iter()
+            .any(|queued| queued.user_message_id == anchor.user_message_id)
+        {
+            return;
+        }
         while queue.len() >= MAX_ANCHORS_PER_THREAD {
             queue.pop_front();
         }

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/types.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/types.rs
@@ -130,6 +130,13 @@ pub enum MlflowTraceOutcome {
     Unset,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompletedSpanEvent {
+    pub name: String,
+    pub at_ms: u64,
+    pub attributes: Vec<(String, String)>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CompletedTraceSpan {
     pub span_id: [u8; 8],
@@ -161,6 +168,8 @@ pub struct CompletedTurnTrace {
     pub output: Option<CapturedValue>,
     pub reasoning: Option<CapturedValue>,
     pub spans: Vec<CompletedTraceSpan>,
+    pub events: Vec<CompletedSpanEvent>,
+    pub dropped_events: u32,
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub cache_read_input_tokens: u64,

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/worker.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/worker.rs
@@ -547,6 +547,8 @@ pub(super) fn diagnostic_trace() -> CompletedTurnTrace {
         output: None,
         reasoning: None,
         spans: Vec::new(),
+        events: Vec::new(),
+        dropped_events: 0,
         input_tokens: 0,
         output_tokens: 0,
         cache_read_input_tokens: 0,

--- a/crates/zorai-daemon/src/agent/mlflow_tracing/worker.rs
+++ b/crates/zorai-daemon/src/agent/mlflow_tracing/worker.rs
@@ -268,8 +268,29 @@ async fn run_worker(
                                 continue;
                             }
                             if let Some(context) = enrich_event(&engine, &event, &observation).await {
+                                let untraced_error_thread = match &event {
+                                    AgentEvent::Error { thread_id, .. }
+                                        if !assembler.has_active_turn(thread_id) =>
+                                    {
+                                        Some(thread_id.clone())
+                                    }
+                                    _ => None,
+                                };
                                 assembler.observe(now_millis(), event, context);
-                                enqueue_completed(&runtime, &config, &mut assembler, &mut pending);
+                                let completed = enqueue_completed(
+                                    &runtime,
+                                    &config,
+                                    &mut assembler,
+                                    &mut pending,
+                                );
+                                if let Some(thread_id) = untraced_error_thread {
+                                    release_anchor_for_untraced_error(
+                                        &runtime,
+                                        &assembler,
+                                        &thread_id,
+                                        completed,
+                                    );
+                                }
                             } else {
                                 release_anchor_for_closed_untraced_turn(&runtime, &assembler, &event);
                             }
@@ -355,6 +376,18 @@ pub(super) fn release_anchor_for_closed_untraced_turn(
     runtime.pop_turn_anchor(thread_id);
 }
 
+pub(super) fn release_anchor_for_untraced_error(
+    runtime: &MlflowTracingRuntime,
+    assembler: &TurnTraceAssembler,
+    thread_id: &str,
+    completed_now: usize,
+) {
+    if completed_now > 0 || assembler.has_active_turn(thread_id) {
+        return;
+    }
+    runtime.pop_turn_anchor(thread_id);
+}
+
 pub(super) fn keep_live_assembler_on_reconfigure(
     runtime: &MlflowTracingRuntime,
     config: &MlflowTracingConfig,
@@ -382,8 +415,10 @@ fn enqueue_completed(
     config: &MlflowTracingConfig,
     assembler: &mut TurnTraceAssembler,
     pending: &mut Vec<CompletedTurnTrace>,
-) {
-    for trace in assembler.drain_completed() {
+) -> usize {
+    let traces = assembler.drain_completed();
+    let completed = traces.len();
+    for trace in traces {
         runtime.pop_turn_anchor(&trace.relationships.thread_id);
         if pending.len() >= config.queue_capacity {
             pending.remove(0);
@@ -397,6 +432,7 @@ fn enqueue_completed(
     status.queue_depth = pending.len();
     status.active_partial_turns = assembler.active_len();
     runtime.status_tx.send_replace(status);
+    completed
 }
 
 async fn flush_pending_with_retry(

--- a/docs/mlflow-tracing.md
+++ b/docs/mlflow-tracing.md
@@ -45,7 +45,7 @@ Independent toggles control:
 - concierge turns;
 - heartbeat/autonomous maintenance (off by default).
 
-One trace represents one Zorai turn. `zorai.thread.id`, task/goal IDs, parent IDs, agent/persona, provider/model, and client surface correlate traces across a conversation and multi-agent workflow.
+One trace represents one Zorai turn. The root span sets `session.id` and `gen_ai.conversation.id` to the Zorai thread ID so MLflow's Session column and **Group by session** can join turns from the same thread. `zorai.thread.id`, task/goal IDs, parent IDs, agent/persona, provider/model, and client surface remain as Zorai-specific correlation attributes.
 
 ## Encrypted custom headers
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -75,7 +75,7 @@ Minimal example:
 ```json
 {
   "name": "zorai-plugin-example",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "zoraiPlugin": {
     "entry": "dist/zorai-plugin.js",
     "format": "script"
@@ -102,7 +102,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.9.46",
+  version: "0.9.47",
   components: {
     ExamplePanel,
   },

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -75,7 +75,7 @@ Minimal example:
 ```json
 {
   "name": "zorai-plugin-example",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "zoraiPlugin": {
     "entry": "dist/zorai-plugin.js",
     "format": "script"
@@ -102,7 +102,7 @@ import ExamplePanel from "./ExamplePanel";
 export const examplePlugin: Plugin = {
   id: "example",
   name: "Example Plugin",
-  version: "0.9.47",
+  version: "0.9.48",
   components: {
     ExamplePanel,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zorai",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zorai",
-      "version": "0.9.47",
+      "version": "0.9.48",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zorai",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zorai",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@honcho-ai/sdk": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zorai",
   "private": true,
-  "version": "0.9.47",
+  "version": "0.9.48",
   "description": "Daemon-first agentic runtime with AI-native workflows",
   "homepage": "https://zorai.app",
   "author": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zorai",
   "private": true,
-  "version": "0.9.46",
+  "version": "0.9.47",
   "description": "Daemon-first agentic runtime with AI-native workflows",
   "homepage": "https://zorai.app",
   "author": {

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -58,7 +58,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>Zorai - Agent Orchestration Workspace</p>
-                    <p>Version 0.9.46</p>
+                    <p>Version 0.9.47</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A thread-first agent orchestration workspace with durable goals, workspace boards,
                         approvals, tools, and daemon-backed runtime state.

--- a/frontend/src/components/settings-panel/AboutTab.tsx
+++ b/frontend/src/components/settings-panel/AboutTab.tsx
@@ -58,7 +58,7 @@ export function AboutTab() {
             <Section title="About">
                 <div style={{ fontSize: 13, lineHeight: 1.6 }}>
                     <p style={{ fontWeight: 600, marginBottom: 8 }}>Zorai - Agent Orchestration Workspace</p>
-                    <p>Version 0.9.47</p>
+                    <p>Version 0.9.48</p>
                     <p style={{ marginTop: 8, color: "var(--text-secondary)" }}>
                         A thread-first agent orchestration workspace with durable goals, workspace boards,
                         approvals, tools, and daemon-backed runtime state.

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.9.47",
+        version: "0.9.48",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/ai-training/registerPlugin.ts
+++ b/frontend/src/plugins/ai-training/registerPlugin.ts
@@ -84,7 +84,7 @@ export function registerAITrainingPlugin() {
     pluginApi.registerPlugin({
         id: "ai-training",
         name: "AI Training",
-        version: "0.9.46",
+        version: "0.9.47",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.9.47",
+        version: "0.9.48",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/plugins/coding-agents/registerPlugin.ts
+++ b/frontend/src/plugins/coding-agents/registerPlugin.ts
@@ -83,7 +83,7 @@ export function registerCodingAgentsPlugin() {
     pluginApi.registerPlugin({
         id: "coding-agents",
         name: "Coding Agents",
-        version: "0.9.46",
+        version: "0.9.47",
         assistantTools: [
             {
                 type: "function",

--- a/frontend/src/zorai/features/settings/SettingsPanels.tsx
+++ b/frontend/src/zorai/features/settings/SettingsPanels.tsx
@@ -64,7 +64,7 @@ export const conciergeReasoningEffortOptions: Array<{ value: AgentSettings["reas
   { value: "xhigh", label: "xhigh" },
   { value: "max", label: "max" },
 ];
-const APP_VERSION = "0.9.47";
+const APP_VERSION = "0.9.48";
 const APP_AUTHOR = "Mariusz Kurman";
 const APP_GITHUB = "mkurman/zorai";
 const APP_HOMEPAGE = "zorai.app";

--- a/frontend/src/zorai/features/settings/SettingsPanels.tsx
+++ b/frontend/src/zorai/features/settings/SettingsPanels.tsx
@@ -64,7 +64,7 @@ export const conciergeReasoningEffortOptions: Array<{ value: AgentSettings["reas
   { value: "xhigh", label: "xhigh" },
   { value: "max", label: "max" },
 ];
-const APP_VERSION = "0.9.46";
+const APP_VERSION = "0.9.47";
 const APP_AUTHOR = "Mariusz Kurman";
 const APP_GITHUB = "mkurman/zorai";
 const APP_HOMEPAGE = "zorai.app";

--- a/frontend/src/zorai/styles/zorai.css
+++ b/frontend/src/zorai/styles/zorai.css
@@ -1518,6 +1518,7 @@
     box-shadow var(--zorai-transition),
     transform var(--zorai-transition),
     opacity var(--zorai-transition);
+  padding: 0;
 }
 
 .zorai-composer-icon-button:hover:not(:disabled) {

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zor-ai",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://zorai.app",

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zor-ai",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "description": "The Agent That Lives - daemon-first AI agent runtime",
   "license": "MIT",
   "homepage": "https://zorai.app",


### PR DESCRIPTION
Merge develop into main for v0.9.48.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon observability assembly and FIFO prompt-anchor accounting, which can mis-label or drop traces if wrong, but does not touch auth or conversation execution.
> 
> **Overview**
> Hardens MLflow turn tracing so empty/late events no longer steal FIFO prompt anchors, and so exported OTLP stays under a byte budget.
> 
> Turns now open only on `Delta`/`Reasoning`/`ToolCall`. Live `RetryStatus` and `ApprovalRequired` become capped root-span events; late ones after a finished turn are ignored. Pre-stream errors still consume their own queued prompt, while a traced error plus deferred `Done` no longer pops the next turn. Duplicate `user_message_id` anchors from runner retries are skipped.
> 
> Completed traces shrink captured payloads (then drop events/spans) until encoded OTLP fits `max_trace_bytes`, marked `partial_reason=trace_bytes`. Root spans also set `session.id` and `gen_ai.conversation.id` to the thread ID for MLflow session grouping.
> 
> Workspace version bump to **0.9.48** (plus a composer icon-button padding tweak).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f48b8a3d476f67fca3924d17cab9e3165459c567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->